### PR TITLE
docs: add additional sections to user docs (bug 1755071)

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -3,78 +3,313 @@
    :caption: Contents:
 
 
+Installation
+============
+Mots can be installed using pip:
+
+.. code-block:: shell
+
+    $ pip install mots
+
+
+You can check for pre-releases by passing ``--pre`` to the ``pip install`` command.
+
+
+Command Line Usage
+==================
+You can get command line usage help by typing ``mots --help`` at the command line.
+
+Initializing a repo
+~~~~~~~~~~~~~~~~~~~
+To create an initial ``mots.yaml`` file in the current repo, run the following command:
+
+.. code-block:: shell
+
+    $ mots init
+
+This will create an empty configuration file that looks like this:
+
+.. code-block:: yaml
+
+    repo: test-repo
+    created_at: '2022-02-11T12:38:57.241494'
+    updated_at: '2022-02-11T12:38:57.241550'
+    people: []
+    modules: []
+
+
+Adding a Module
+~~~~~~~~~~~~~~~
+To add a new module to your mots configuration, you can either add it directly to the YAML file, or you could use the interactive ``mots module add`` command.
+
+.. code-block:: shell
+
+    $ mots module add
+    Enter a machine name for the new module (e.g. core_accessibility): example
+    Enter a human readable name (e.g. Core: Accessibility): Example
+    Enter a description for the new module: This is an example module.
+    Enter a comma separated list of owner bugzilla IDs: 633708
+    Enter a comma separated list of peer bugzilla IDs:
+    Enter a comma separated list of paths to include: example.text
+    Enter a comma separated list of paths to exclude:
+    Enter a machine name of the parent module (optional):
+
+The above code will create a new module in ``mots.yaml`` so that the file will look like this:
+
+.. code-block:: yaml
+
+	repo: test-repo
+	created_at: '2022-02-14T09:08:38.055168'
+	updated_at: '2022-02-14T09:10:08.096987'
+	people: []
+	modules:
+	  - machine_name: example
+		name: Example
+		description: This is an example module.
+		includes:
+		  - example.text
+		excludes: []
+		owners:
+		  - bmo_id: 633708
+		peers: []
+		meta:
+
+
+Note that the only required attribute under "owners" is the ``bmo_id`` field. You can optionally add this information manually, and then run the ``mots clean`` command which will query the Bugzilla API to fetch the remaining information.
+
+
+.. code-block:: yaml
+
+	repo: test-repo
+	created_at: '2022-02-14T09:08:38.055168'
+	updated_at: '2022-02-14T09:11:32.991309'
+	people:
+	  - &zeid
+		bmo_id: 633708
+		name: Zeid Zabaneh
+		info: '[:zeid]'
+		nick: zeid
+	modules:
+	  - machine_name: example
+		name: Example
+		description: This is an example module.
+		includes:
+		  - example.text
+		excludes: []
+		owners:
+		  - *zeid
+		peers: []
+		meta:
+
+
+Adding a Submodule
+~~~~~~~~~~~~~~~~~~
+To add a submodule, follow the same instructions for adding a module, but specify the machine name of the parent module at the input prompt. For example:
+
+.. code-block:: shell
+
+	$ mots module add
+	Enter a machine name for the new module (e.g. core_accessibility): example_submodule
+	Enter a human readable name (e.g. Core: Accessibility): Example Submodule
+	Enter a description for the new module: This module is a submodule of the "Example" module.
+	Enter a comma separated list of owner bugzilla IDs:
+	Enter a comma separated list of peer bugzilla IDs: 633708
+	Enter a comma separated list of paths to include: example_submodule/**/*
+	Enter a comma separated list of paths to exclude:
+	Enter a machine name of the parent module (optional): example
+	$ mots clean
+
+This will result in a file that looks like this:
+
+.. code-block:: yaml
+
+	repo: test-repo
+	created_at: '2022-02-14T09:08:38.055168'
+	updated_at: '2022-02-14T09:32:52.387222'
+	people:
+	  - &zeid
+		bmo_id: 633708
+		name: Zeid Zabaneh
+		info: '[:zeid]'
+		nick: zeid
+	modules:
+	  - machine_name: example
+		name: Example
+		description: This is an example module.
+		includes:
+		  - example.text
+		excludes: []
+		owners:
+		  - *zeid
+		peers: []
+		meta:
+		submodules:
+		  - machine_name: example_submodule
+			name: Example Submodule
+			description: This module is a submodule of the "Example" module.
+			includes:
+			  - example_submodule/**/*
+			excludes: []
+			owners: []
+			peers:
+			  - *zeid
+			meta:
+
+Cleaning ``mots.yaml``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``mots clean`` to automatically sort and synchronize data in the ``mots.yaml`` configuration file. This command requires a ``BUGZILLA_API_KEY`` environment variable to be set. You can do this by running the following commands, replacing the redacted key with an actual Bugzilla API key:
+
+.. code-block:: shell
+
+    $ export BUGZILLA_API_KEY=***************************************
+    $ mots clean
+
+
+.. note::
+    You can generate a Bugzilla API key in your User Preferences page under the `API Keys <https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey>`_ tab.
+
+
+Validating ``mots.yaml``
+~~~~~~~~~~~~~~~~~~~~~~~~
+Validating your modules ensures that you have all the required keys in your configuration file, and that you have unique machine names for all your modules and submodules. Run the following command to do automatic validation:
+
+.. code-block:: shell
+
+    $ mots validate
+
+Any modules or submodules that have errors in them will be included in any error output from this command.
+
+Querying a File Path
+~~~~~~~~~~~~~~~~~~~~
+You can determine which module a file path belongs to by using the ``mots query`` command. This command takes an arbitrary number of path arguments, and prints out the modules on the screen.
+
+.. code-block:: shell
+
+	$ mots query example.text example_submodule/test2
+	example.text:example
+	example_submodule/test2:example_submodule
+
+
+Exporting
+~~~~~~~~~
+Using the ``mots export`` command, the configuration can be exported in a different format. Currently only `reStructuredText` is supported. This command will output the result to standard output.
+
+.. code-block:: shell
+
+	$ mots export > mots.rst
+
+The exported data will look like this:
+
+.. code-block:: rst
+
+	=======
+	Modules
+	=======
+
+	Example
+	~~~~~~
+	This is an example module.
+
+	.. list-table::
+		:stub-columns: 1
+
+		* - Owner(s)
+		  - zeid
+		* - Includes
+		  - example.text
+
+	Example Submodule
+	=================
+
+	This module is a submodule of the "Example" module.
+
+	.. list-table::
+		:stub-columns: 1
+
+		* - Owner(s)
+		  - zeid
+		* - Peer(s)
+		  - zeid
+		* - Includes
+		  - example_submodule/\*\*/\*
+
+Debugging
+~~~~~~~~~
+To enable debug mode for any command, pass ``--debug`` before the command. For example:
+
+.. code-block:: shell
+
+	$ mots --debug query example.text
+
 Developer Interface
 ===================
 
 Module
-------
+~~~~~~
 .. automodule:: mots.module
     :members:
 
 
 Directory
----------
+~~~~~~~~~
 .. automodule:: mots.directory
     :members:
 
 
 CLI
----------
+~~~
 .. automodule:: mots.cli
     :members:
 
 
 Config
----------
+~~~~~~
 .. automodule:: mots.config
     :members:
 
 
 Utils
----------
+~~~~~
 .. automodule:: mots.utils
     :members:
-
-Command Line Usage
-==================
-You can get command line usage help by typing ``mots --help`` at the command line.
 
 
 Development environment
 =======================
 To set up a local development environment, run the following commands. Replace the python version with the desired version on your local machine.
 
-.. code-block:: bash
+.. code-block:: shell
 
     make dev-env PY=python3.9
-    source .mots-env/bin/activate
     make dev
 
 The above commands will set up a local development environment using the provided python version available on your machine, and subsequently install all required packages in that environment.
 
 Generate coverage report
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 To generate a standard coverage report, run:
 
-.. code-block:: bash
+.. code-block:: shell
 
 	make cov
 
 To generate an html coverage report, run:
 
-.. code-block:: bash
+.. code-block:: shell
 
 	make cov-html
 	make serve-cov
 
 Then navigate to your web browser.
 
+
 Other make commands
--------------------
+~~~~~~~~~~~~~~~~~~~
 Run `make` to see all available commands.
 
-.. code-block:: bash
+.. code-block:: shell
 
 	usage: make <target>
 
@@ -90,3 +325,4 @@ Run `make` to see all available commands.
 		requirements  regenerate requirements.txt
 		serve-cov     simple http server for coverage report
 		serve-docs    simple http server for docs
+		test          run the test suite

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -1,3 +1,7 @@
+======================================
+mots - Module Ownership in Tree System
+======================================
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -90,6 +90,7 @@ def add(args: argparse.Namespace) -> None:
             " for the new module (e.g. core_accessibility): "
         ),
         "name": input("Enter a human readable name (e.g. Core: Accessibility): "),
+        "description": input("Enter a description for the new module: "),
         "owners": get_list_input("Enter a comma separated list of owner bugzilla IDs"),
         "peers": get_list_input("Enter a comma separated list of peer bugzilla IDs"),
         "includes": get_list_input("Enter a comma separated list of paths to include"),

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -140,7 +140,7 @@ def clean(file_config: FileConfig, write: bool = True):
         nicks = []
         for person in file_config.config["people"]:
             machine_readable_nick = generate_machine_readable_name(
-                person["nick"], keep_case=True
+                person.get("nick", ""), keep_case=True
             )
             if machine_readable_nick in nicks or not machine_readable_nick:
                 continue

--- a/src/mots/export.py
+++ b/src/mots/export.py
@@ -31,7 +31,7 @@ class Exporter:
         loader = jinja2.FileSystemLoader(
             searchpath=importlib_resources.files("mots") / "templates"
         )
-        env = jinja2.Environment(loader=loader)
+        env = jinja2.Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
         template = env.get_template("directory.template.rst")
         out = template.render(directory=self.directory)
         return out

--- a/src/mots/module.py
+++ b/src/mots/module.py
@@ -29,6 +29,9 @@ class Module:
     :param exclude_submodule_paths: when True, paths in submodules are excluded
     :param exclude_module_paths: when True, common paths in other modules are excluded
         from the directory index
+
+    The ``Module`` class wraps modules and submodules in a configuration, and provides
+    useful methods for validation, calculating paths, and serialization.
     """
 
     def __repr__(self):
@@ -94,7 +97,7 @@ class Module:
     def calculate_paths(self):
         """Calculate paths based on inclusions and exclusions.
 
-        Upon calling this method, excluded paths are parsed using `pathlib.Path.rglob`
+        Upon calling this method, excluded paths are parsed using ``pathlib.Path.rglob``
         and then subtracted from the included paths, which are parsed in the same way.
 
         :rtype: set
@@ -124,10 +127,14 @@ class Module:
         return paths
 
     def serialize(self):
-        """Return a dictionary with relevant module information."""
+        """Return a dictionary with relevant module information.
+
+        :rtype: dict
+        """
         serialized = {
             "machine_name": self.machine_name,
             "name": self.name,
+            "description": self.description,
             "includes": self.includes,
             "excludes": self.excludes,
             "owners": self.owners,

--- a/src/mots/templates/directory.template.rst
+++ b/src/mots/templates/directory.template.rst
@@ -1,13 +1,11 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public #}
 {# License, v. 2.0. If a copy of the MPL was not distributed with this #}
 {# file, You can obtain one at https://mozilla.org/MPL/2.0/. #}
-
 {%- macro module_entry(module, is_submodule=False) -%}
 {{ module.name }}
 {{ "~" * module.name|length if not is_submodule else "=" * module.name|length }}
 
 {{ module.description }}
-
 {% if not module.owners %}
 .. warning::
 
@@ -46,10 +44,10 @@
       - {{ module.meta.components|join(", ") }}
 {% endif %}
 {% endmacro %}
-
 =======
 Modules
 =======
+
 {{ directory.description }}
 
 {%- for module in directory.modules -%}

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -12,7 +12,7 @@ from mots.config import FileConfig
 def test_directory__Directory(repo):
     file_config = FileConfig(repo / "mots.yml")
     directory = Directory(file_config)
-    directory.load(full_paths=True, query_bmo=False)
+    directory.load(full_paths=True)
 
     rp = directory.repo_path
     di = directory.index
@@ -55,11 +55,11 @@ def test_directory__Directory(repo):
 def test_directory__Directory_new_path(repo):
     file_config = FileConfig(repo / "mots.yml")
     directory = Directory(file_config)
-    directory.load(query_bmo=False)
+    directory.load()
     new_file_path = directory.repo_path / "canines/chihuahuas/deer_head"
     new_file_path.touch()
     assert new_file_path not in directory.index
-    directory.load(query_bmo=False)
+    directory.load()
     assert new_file_path in directory.index
     assert len(directory.index[new_file_path]) == 1
     assert directory.index[new_file_path][0].machine_name == "pets"
@@ -68,20 +68,20 @@ def test_directory__Directory_new_path(repo):
 def test_directory__Directory_deleted_path(repo):
     file_config = FileConfig(repo / "mots.yml")
     directory = Directory(file_config)
-    directory.load(query_bmo=False)
+    directory.load()
     existing_path = directory.repo_path / "canines/chihuahuas/apple_head"
     assert len(directory.index[existing_path]) == 1
     assert directory.index[existing_path][0].machine_name == "pets"
     assert existing_path in directory.index
     existing_path.unlink()
-    directory.load(query_bmo=False)
+    directory.load()
     assert existing_path not in directory.index
 
 
 def test_directory__Directory__query(repo):
     file_config = FileConfig(repo / "mots.yml")
     directory = Directory(file_config)
-    directory.load(query_bmo=False)
+    directory.load()
 
     paths_to_check = [
         "canines/chihuahuas/apple_head",
@@ -113,7 +113,7 @@ def test_directory__Directory__query(repo):
 def test_directory__Directory__query_merging(repo):
     file_config = FileConfig(repo / "mots.yml")
     directory = Directory(file_config)
-    directory.load(query_bmo=False)
+    directory.load()
 
     paths_to_check_1 = [
         "canines/chihuahuas/apple_head",


### PR DESCRIPTION
Add a few more sections to the docs to include command line usage examples and installation instructions.

There is also a bug fix to remove extra newlines and white space from generated rst files.

Built docs can be viewed here: https://mots.readthedocs.io/en/develop/