### PR TITLE
typing: clarify types in `config.py`, `module.py`

### DIFF
--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -6,7 +6,10 @@
 
 from collections import defaultdict
 import logging
-from typing import List
+from typing import (
+    List,
+    Optional,
+)
 
 from datetime import datetime
 from pathlib import Path
@@ -151,7 +154,7 @@ def clean(file_config: FileConfig, write: bool = True):
         file_config.write()
 
 
-def validate(config: dict, repo_path: str) -> List[str]:
+def validate(config: dict, repo_path: str) -> Optional[List[str]]:
     """Validate the current state of the config file.
 
     - Check if top-level dictionary contains required keys
@@ -184,7 +187,7 @@ def validate(config: dict, repo_path: str) -> List[str]:
         return [error_msg]
 
     errors = []
-    for i, module in enumerate(config["modules"]):
+    for module in config["modules"]:
         module = Module(repo_path=repo_path, **module)
         validation_errors = module.validate()
         if validation_errors:

--- a/src/mots/module.py
+++ b/src/mots/module.py
@@ -7,7 +7,10 @@
 import logging
 from pathlib import Path
 from pprint import pprint as print
-from typing import List
+from typing import (
+    List,
+    Union,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +44,7 @@ class Module:
     def __init__(
         self,
         machine_name: str,
-        repo_path: str,
+        repo_path: Union[str, Path],
         name: str = "",
         description: str = "",
         includes: List[str] = None,


### PR DESCRIPTION
`repo_path` can be both a `str` and a `Path`, so update the
type to a `Union` of the two. `validate` returns `List[str]`
but it can also return `None` if there are no validation errors,
so mark it as `Optional`.

Also remove an unused instance of `i` and the `enumerate` that
causes it.
