### PR TITLE
config: formatting improvements when cleaning (bug 1764383)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           name: setup
           command: |
             set -e
+            sudo apt-get update
             sudo apt-get install python3-venv
             mkdir -p /tmp/test-reports
             make dev-env

--- a/mots.yaml
+++ b/mots.yaml
@@ -1,11 +1,14 @@
 repo: mots
 created_at: '2022-02-02T14:48:50.574414'
-updated_at: '2022-04-12T13:35:10.995339'
+updated_at: '2022-06-16T13:04:27.354854'
 export:
   path: ./mots.rst
   format: rst
 people:
-  - &zeid {bmo_id: 633708, name: Zeid Zabaneh, nick: zeid}
+  - &zeid
+    bmo_id: 633708
+    name: Zeid Zabaneh
+    nick: zeid
 modules:
   - machine_name: main
     name: Main

--- a/mots.yaml
+++ b/mots.yaml
@@ -1,15 +1,11 @@
 repo: mots
 created_at: '2022-02-02T14:48:50.574414'
-updated_at: '2022-04-05T09:21:28.220398'
+updated_at: '2022-04-12T13:35:10.995339'
 export:
   path: ./mots.rst
   format: rst
 people:
-  - &zeid
-    bmo_id: 633708
-    name: Zeid Zabaneh
-    info: '[:zeid]'
-    nick: zeid
+  - &zeid {bmo_id: 633708, name: Zeid Zabaneh, nick: zeid}
 modules:
   - machine_name: main
     name: Main

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -150,7 +150,6 @@ def clean(file_config: FileConfig, write: bool = True):
                 continue
             nicks.append(machine_readable_nick)
             person.yaml_set_anchor(machine_readable_nick)
-            person.fa.set_flow_style()
 
         file_config.write()
 

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -141,6 +141,7 @@ def clean(file_config: FileConfig, write: bool = True):
         file_config.load()
 
         nicks = []
+        file_config.config["people"].sort(key=lambda p: p["nick"].lower())
         for person in file_config.config["people"]:
             machine_readable_nick = generate_machine_readable_name(
                 person.get("nick", ""), keep_case=True
@@ -149,6 +150,7 @@ def clean(file_config: FileConfig, write: bool = True):
                 continue
             nicks.append(machine_readable_nick)
             person.yaml_set_anchor(machine_readable_nick)
+            person.fa.set_flow_style()
 
         file_config.write()
 

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -163,7 +163,6 @@ class Person:
 
     bmo_id: int
     name: str
-    info: str
     nick: str
 
     def __hash__(self):
@@ -192,10 +191,8 @@ class People:
 
                 parsed_real_name = parse_real_name(bmo_datum["real_name"])
                 person["name"] = parsed_real_name["name"]
-                person["info"] = parsed_real_name["info"]
             else:
                 person["name"] = person.get("name", "")
-                person["info"] = person.get("info", "")
                 person["nick"] = person.get("nick", "")
 
             self.people.append(Person(**person))

--- a/src/mots/utils.py
+++ b/src/mots/utils.py
@@ -34,8 +34,10 @@ def get_list_input(text: str):
 
 def parse_real_name(real_name):
     """Parse real_name into name and info."""
-    pattern = re.compile(r"^(?P<name>[\w\ ]+?)?\ ?(?P<info>[\(\[\|\:].*)?$")
+    pattern = re.compile(r"^(?P<name>[\w\ \-]*)?\ ?(?P<info>\W.*)?$")
     match = pattern.match(real_name)
+    if not match:
+        return {"name": "", "info": real_name}
     data = match.groupdict()
     return {k: v.strip() if v else "" for k, v in data.items()}
 

--- a/src/mots/utils.py
+++ b/src/mots/utils.py
@@ -10,6 +10,8 @@ import re
 
 logger = logging.getLogger(__name__)
 
+REAL_NAME_RE = re.compile(r"^(?P<name>[\w\ \-]*)?\ ?(?P<info>\W.*)?$")
+
 
 def generate_machine_readable_name(display_name, keep_case=False):
     """Turn spaces into underscores, and lower the case. Strip all but alphanumerics."""
@@ -34,8 +36,7 @@ def get_list_input(text: str):
 
 def parse_real_name(real_name):
     """Parse real_name into name and info."""
-    pattern = re.compile(r"^(?P<name>[\w\ \-]*)?\ ?(?P<info>\W.*)?$")
-    match = pattern.match(real_name)
+    match = REAL_NAME_RE.match(real_name)
     if not match:
         return {"name": "", "info": real_name}
     data = match.groupdict()

--- a/src/mots/utils.py
+++ b/src/mots/utils.py
@@ -36,11 +36,8 @@ def parse_real_name(real_name):
     """Parse real_name into name and info."""
     pattern = re.compile(r"^(?P<name>[\w\ ]+?)?\ ?(?P<info>[\(\[\|\:].*)?$")
     match = pattern.match(real_name)
-    if match:
-        data = match.groupdict()
-        return {k: v.strip() if v else "" for k, v in data.items()}
-    else:
-        return {"name": None, "info": None}
+    data = match.groupdict()
+    return {k: v.strip() if v else "" for k, v in data.items()}
 
 
 def mkdir_if_not_exists(path: Path):

--- a/src/mots/utils.py
+++ b/src/mots/utils.py
@@ -37,7 +37,8 @@ def parse_real_name(real_name):
     pattern = re.compile(r"^(?P<name>[\w\ ]+?)?\ ?(?P<info>[\(\[\|\:].*)?$")
     match = pattern.match(real_name)
     if match:
-        return match.groupdict()
+        data = match.groupdict()
+        return {k: v.strip() if v else "" for k, v in data.items()}
     else:
         return {"name": None, "info": None}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,9 +57,9 @@ def repo(tmp_path, config):
 @pytest.fixture
 def config():
     people = [
-        {"info": "testing", "name": "jane", "nick": "jane", "bmo_id": 0},
-        {"info": "testing", "name": "jill", "nick": "jill", "bmo_id": 1},
-        {"info": "testing", "name": "otis", "nick": "otis", "bmo_id": 2},
+        {"name": "jane", "nick": "jane", "bmo_id": 0},
+        {"name": "jill", "nick": "jill", "bmo_id": 1},
+        {"name": "otis", "nick": "otis", "bmo_id": 2},
     ]
     return {
         "repo": "test_repo",

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -102,10 +102,10 @@ def test_directory__Directory__query(repo):
         "felines/persian",
     }
     assert set(result.owners) == {
-        Person(bmo_id=2, name="otis", info="testing", nick="otis")
+        Person(bmo_id=2, name="otis", nick="otis")
     }
     assert set(result.peers) == {
-        Person(bmo_id=1, name="jill", info="testing", nick="jill")
+        Person(bmo_id=1, name="jill", nick="jill")
     }
     assert result.rejected_paths == ["felines/maine_coon"]
 
@@ -141,9 +141,9 @@ def test_directory__Directory__query_merging(repo):
         "felines/persian",
     }
     assert set(result.owners) == {
-        Person(bmo_id=2, name="otis", info="testing", nick="otis")
+        Person(bmo_id=2, name="otis", nick="otis")
     }
     assert set(result.peers) == {
-        Person(bmo_id=1, name="jill", info="testing", nick="jill")
+        Person(bmo_id=1, name="jill", nick="jill")
     }
     assert result.rejected_paths == ["felines/maine_coon"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,6 +67,17 @@ def test_parse_real_name():
         "info": ":test",
     }
 
+    # This test is not great, but some folks have their e-mail instead of name.
+    assert parse_real_name("tester@testerson.example (:test)") == {
+        "name": "tester",
+        "info": "@testerson.example (:test)",
+    }
+
+    assert parse_real_name("Emoji Tester💡 :tester") == {
+        "name": "Emoji Tester",
+        "info": "💡 :tester",
+    }
+
     assert parse_real_name("tester testerson | TEST | te/st") == {
         "name": "tester testerson",
         "info": "| TEST | te/st",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,37 +74,37 @@ def test_parse_real_name():
 
     assert parse_real_name("tester testerson") == {
         "name": "tester testerson",
-        "info": None,
+        "info": "",
     }
 
     assert parse_real_name("tester") == {
         "name": "tester",
-        "info": None,
+        "info": "",
     }
 
     assert parse_real_name("(:bees)") == {
-        "name": None,
+        "name": "",
         "info": "(:bees)",
     }
 
     assert parse_real_name("[:bees]") == {
-        "name": None,
+        "name": "",
         "info": "[:bees]",
     }
 
     assert parse_real_name("[bees]") == {
-        "name": None,
+        "name": "",
         "info": "[bees]",
     }
 
     assert parse_real_name("(bees)") == {
-        "name": None,
+        "name": "",
         "info": "(bees)",
     }
 
     assert parse_real_name("") == {
-        "name": None,
-        "info": None,
+        "name": "",
+        "info": "",
     }
 
 


### PR DESCRIPTION
- sort people alphabetically so they are easier to find
- show people definitions in a more compact way (flow style)
- show blank string instead of null BMO values
- strip additional whitespace from BMO vaules
- remove extra info from people definitions
- add a test case + adjust regex to match names more liberally
- add `apt-get update` to circleci commands