### PR TITLE
docs: add source .mots-env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To set up a local development environment, run the following commands. Optionall
 
 ```shell
 make dev-env PY=python3.9
+source .mots-env
 make dev
 ```
 


### PR DESCRIPTION
Without this command, `make dev` will install outside the virtual environment.