### PR TITLE
directory: improve support for empty QueryResult (bug 1790047)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 dist/
 documentation/_build
 htmlcov/
+*.egg-info

--- a/src/mots/__init__.py
+++ b/src/mots/__init__.py
@@ -8,4 +8,4 @@ Mots is the in-tree module ownership system.
 This library helps you track who owns what parts of the source code!
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """Directory classes for mots."""
+from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import asdict
@@ -125,7 +126,14 @@ class QueryResult:
         "peers",
     }
 
-    def __init__(self, result, rejected):
+    def __init__(
+        self,
+        result: dict[str, list[Module]] | None = None,
+        rejected: list[str] | None = None,
+    ):
+        result = result or {}
+        rejected = rejected or []
+
         data = {k: set() for k in self.data_keys}
         self.path_map = result
 
@@ -142,11 +150,15 @@ class QueryResult:
         for key in data:
             setattr(self, key, list(data[key]))
 
+    def __bool__(self):
+        """Return whether there is any data in this object."""
+        return bool(self.path_map)
+
     def __add__(self, query_result: "QueryResult") -> "QueryResult":
         """Merge the data from both QueryResult objects."""
         path_map = self.path_map.copy()
         path_map.update(query_result.path_map)
-        rejected_paths = set.intersection(
+        rejected_paths = set.union(
             set(self.rejected_paths),
             set(query_result.rejected_paths),
         )

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -6,6 +6,7 @@
 
 from mots.directory import Directory
 from mots.directory import Person
+from mots.directory import QueryResult
 from mots.config import FileConfig
 
 
@@ -139,3 +140,42 @@ def test_directory__Directory__query_merging(repo):
     assert set(result.owners) == {Person(bmo_id=2, name="otis", nick="otis")}
     assert set(result.peers) == {Person(bmo_id=1, name="jill", nick="jill")}
     assert result.rejected_paths == ["felines/maine_coon"]
+
+
+def test_directory__Directory__query_add_to_empty_QueryResult(repo):
+    file_config = FileConfig(repo / "mots.yml")
+    directory = Directory(file_config)
+    directory.load()
+
+    paths_to_check_1 = [
+        "canines/chihuahuas/apple_head",
+        "birds/parrot",
+        "felines/maine_coon",
+    ]
+
+    result_1 = directory.query(*paths_to_check_1)
+
+    result = result_1 + QueryResult()
+
+    assert result.path_map == {
+        "canines/chihuahuas/apple_head": [directory.modules_by_machine_name["pets"]],
+        "birds/parrot": [directory.modules_by_machine_name["pets"]],
+    }
+    assert set(result.paths) == {
+        "canines/chihuahuas/apple_head",
+        "birds/parrot",
+    }
+    assert set(result.owners) == {Person(bmo_id=2, name="otis", nick="otis")}
+    assert set(result.peers) == {Person(bmo_id=1, name="jill", nick="jill")}
+    assert result.rejected_paths == ["felines/maine_coon"]
+
+
+def test_directory__QueryResult_empty():
+    empty_result = QueryResult()
+    assert not empty_result
+
+
+def test_directory__QueryResult_empty_addition():
+    empty_result = QueryResult()
+    other_empty_result = QueryResult()
+    assert not (empty_result + other_empty_result)

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -4,9 +4,8 @@
 
 """Tests for directory module."""
 
-from mots.directory import Directory
-from mots.directory import Person
-from mots.directory import QueryResult
+from mots.directory import Directory, Person, QueryResult
+from mots.module import Module
 from mots.config import FileConfig
 
 
@@ -173,6 +172,12 @@ def test_directory__Directory__query_add_to_empty_QueryResult(repo):
 def test_directory__QueryResult_empty():
     empty_result = QueryResult()
     assert not empty_result
+
+
+def test_directory__QueryResult_nonempty():
+    test_module = Module(machine_name="test_module", repo_path="/repos/test")
+    empty_result = QueryResult({"test_path": [test_module]}, ["rejected_path"])
+    assert empty_result
 
 
 def test_directory__QueryResult_empty_addition():


### PR DESCRIPTION
- add `QueryResult.__bool__`
- make `result` and `rejected` parameters optional
- fix bug when adding rejected paths