### PR TITLE
cli: show better message when API key is missing (bug 1792066)

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -173,6 +173,9 @@ Use ``mots clean`` to automatically sort and synchronize data in the ``mots.yaml
 .. note::
     You can generate a Bugzilla API key in your User Preferences page under the `API Keys <https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey>`_ tab.
 
+.. note::
+    A Bugzilla API key is required to allow mots to query Bugzilla for user information.
+
 
 Validating ``mots.yaml``
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/mots/bmo.py
+++ b/src/mots/bmo.py
@@ -15,6 +15,12 @@ from mots.settings import settings
 logger = logging.getLogger(__name__)
 
 
+class MissingBugzillaAPIKey(Exception):
+    """Raised when a Bugzilla API key was not detected in settings."""
+
+    pass
+
+
 def get_bmo_data(people: list) -> dict:
     """Fetch an updated dictionary from Bugzilla with user data.
 
@@ -32,10 +38,7 @@ class BMOClient:
         if not token:
             token = settings.BUGZILLA_API_KEY
             if not token:
-                raise ValueError(
-                    "Bugzilla API Key is missing and no other "
-                    "token was explicitly provided"
-                )
+                raise MissingBugzillaAPIKey()
         self._headers = {"X-BUGZILLA-API-KEY": token, "User-Agent": settings.USER_AGENT}
         self._base_url = base_url
 

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -12,6 +12,7 @@ import sys
 
 from mots import module
 from mots import config
+from mots.bmo import MissingBugzillaAPIKey
 from mots.ci import validate_version_tag
 from mots.directory import Directory
 from mots.export import export_to_format
@@ -59,7 +60,19 @@ def clean(args: argparse.Namespace) -> None:
     """Run clean methods for configuration file and write to disk."""
     file_config = config.FileConfig(Path(args.path))
     file_config.load()
-    config.clean(file_config)
+    try:
+        config.clean(file_config)
+    except MissingBugzillaAPIKey:
+        logger.error("Could not detect a Bugzilla API Key.")
+        messages = (
+            "Either set it in your environment (MOTS_BUGZILLA_API KEY) or add it to "
+            "your settings file by running: "
+            "`mots settings write BUGZILLA_API_KEY <your API key>`.",
+            "You can generate a Bugzilla API key in your User Preferences page under"
+            "the API Keys tab.",
+        )
+        print("\n".join(messages))
+        sys.exit(1)
 
 
 def check_hashes(args: argparse.Namespace) -> None:


### PR DESCRIPTION
- also add note in documentation about why the API key is needed