### PR TITLE
cli: allow hidden input for secure keys (bug 1796651)

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -166,7 +166,10 @@ Use ``mots clean`` to automatically sort and synchronize data in the ``mots.yaml
 
 .. code-block:: shell
 
-    $ mots settings write BUGZILLA_API_KEY ***************************************
+    $ mots settings write BUGZILLA_API_KEY
+    $ Enter value for BUGZILLA_API_KEY: <hidden input>
+    2022-10-20 15:02:40,439 cli        INFO     BUGZILLA_API_KEY is now set to ********** (str) in overrides file.
+    2022-10-20 15:02:40,442 cli        INFO     Success!
     $ mots clean
 
 

--- a/src/mots/settings.py
+++ b/src/mots/settings.py
@@ -45,6 +45,11 @@ class Settings:
         "VERSION": __version__,
     }
 
+    # NOTE: keys present in SECURE_KEYS will not be added to logs. Users will be
+    # prompted using `getpass`, however they will still be stored as cleartext
+    # in the settings file, like all other values.
+    SECURE_KEYS = ("BUGZILLA_API_KEY",)
+
     def __init__(self, **kwargs):
         self.settings = {}
         self.overrides = kwargs


### PR DESCRIPTION
- add input option (or hidden input) when writing settings