### PR TITLE
config: ensure persons are initialized with required keys (bug 1797083)

### DIFF
--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 
 from mots.bmo import get_bmo_data
-from mots.directory import Directory, People
+from mots.directory import Directory, People, Person
 from mots.export import export_to_format
 from mots.module import Module
 from mots.utils import generate_machine_readable_name
@@ -160,6 +160,7 @@ def clean(file_config: FileConfig, write: bool = True):
             if key not in module or not module[key]:
                 continue
             for i, person in enumerate(module[key]):
+                person = Person(**person).serialize()
                 if person["bmo_id"] not in directory.people.by_bmo_id:
                     file_config.config["people"].append(person)
                     module[key][i] = person

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -162,12 +162,16 @@ class Person:
     """A class representing a person."""
 
     bmo_id: int
-    name: str
-    nick: str
+    name: str | None = ""
+    nick: str | None = ""
 
     def __hash__(self):
         """Return a unique identifier for this person."""
         return self.bmo_id
+
+    def serialize(self):
+        """Return dictionary representation of Person."""
+        return asdict(self)
 
 
 class People:
@@ -198,6 +202,7 @@ class People:
             self.people.append(Person(**person))
             self.by_bmo_id[person["bmo_id"]] = i
             logger.debug(f"Person {person} added to position {i}.")
+
         self.serialized = [asdict(person) for person in self.people]
 
     def refresh_by_bmo_id(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,3 +121,31 @@ def config():
             },
         ],
     }
+
+
+@pytest.fixture
+def config_with_bmo_ids_only():
+    return {
+        "repo": "test_repo",
+        "created_at": "2021-09-10 12:53:22.383393",
+        "updated_at": "2021-09-10 12:53:22.383393",
+        "people": [],
+        "export": {"format": "rst", "path": "mots.rst"},
+        "modules": [
+            {
+                "machine_name": "domesticated_animals",
+                "exclude_submodule_paths": True,
+                "exclude_module_paths": True,
+                "includes": [
+                    "canines/**/*",
+                    "felines/**/*",
+                    "bovines/**/*",
+                    "birds/**/*",
+                    "pigs/**/*",
+                ],
+                "excludes": ["canines/red_fox"],
+                "owners": [{"bmo_id": 1}],
+                "peers": [{"bmo_id": 1}],
+            }
+        ],
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@
 
 """Test config module."""
 
-from mots.config import calculate_hashes, FileConfig
+from mots.config import calculate_hashes, FileConfig, clean
 
 
 def test_calculate_hashes(config):
@@ -32,3 +32,11 @@ def test_FileConfig__check_hashes(repo):
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
         "export file is out of date.",
     ]
+
+
+def test_clean_with_no_nick(repo, config_with_bmo_ids_only):
+    """Ensures clean function runs without any errors if nick is missing."""
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.config = config_with_bmo_ids_only
+    file_config.write()
+    clean(file_config)

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -4,6 +4,8 @@
 
 """Tests for directory module."""
 
+import pytest
+
 from mots.directory import Directory
 from mots.directory import Person
 from mots.config import FileConfig
@@ -139,3 +141,18 @@ def test_directory__Directory__query_merging(repo):
     assert set(result.owners) == {Person(bmo_id=2, name="otis", nick="otis")}
     assert set(result.peers) == {Person(bmo_id=1, name="jill", nick="jill")}
     assert result.rejected_paths == ["felines/maine_coon"]
+
+
+def test_Person():
+    with pytest.raises(TypeError):
+        Person()
+
+    person = Person(0)
+    assert person.bmo_id == 0
+    assert person.nick == ""
+    assert person.name == ""
+
+    person = Person(0, name="Tester", nick="tester")
+    assert person.bmo_id == 0
+    assert person.name == "Tester"
+    assert person.nick == "tester"


### PR DESCRIPTION
- make `Person.nick` and `Person.name` optional, default to empty string
- serialize newly added persons before adding to people entry
- add test to test Person class