### PR TITLE
config: reference anchors when parsing emeritus fields (bug 1798756)

### DIFF
--- a/src/mots/__init__.py
+++ b/src/mots/__init__.py
@@ -8,4 +8,4 @@ Mots is the in-tree module ownership system.
 This library helps you track who owns what parts of the source code!
 """
 
-__version__ = "0.3.2.post1"
+__version__ = "0.3.3"

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -107,6 +107,54 @@ class FileConfig:
             yaml.dump(self.config, f)
 
 
+def check_nested_keys_for_value(dictionary: dict, keys, boolean=True) -> bool:
+    """Check a nested key for a value. If boolean is False, checks if the key exists.
+
+    For example:
+        >>> test = {"a": {"b": {"c": 1, "d": None}}}
+        >>> check_nested_keys_for_value(test, ["a", "b", "c"])
+        True
+        >>> check_nested_keys_for_value(test, ["a", "b", "e"])
+        False
+        >>> check_nested_keys_for_value(test, ["a", "b", "c", "d"])
+        False
+    """
+    value = dictionary
+    for key in keys:
+        if value and isinstance(value, dict):
+            value = value.get(key)
+        else:
+            return False
+    if boolean:
+        return bool(value)
+    else:
+        return True
+
+
+def anchor_people_for_module(
+    i: int,
+    person: dict,
+    key: str,
+    file_config: FileConfig,
+    directory: Directory,
+    module: Module,
+) -> None:
+    """Associate person with a reference to a directory entry if possible."""
+    logger.debug(f"Anchoring {person}({i}) as {key} to {module['machine_name']}")
+    if "emeritus" in key:
+        reference = module["meta"][key]
+    else:
+        reference = module[key]
+    if person["bmo_id"] not in directory.people.by_bmo_id:
+        file_config.config["people"].append(person)
+        reference[i] = person
+        directory.people.refresh_by_bmo_id()
+    else:
+        reference[i] = file_config.config["people"][
+            directory.people.by_bmo_id[person["bmo_id"]]
+        ]
+
+
 def calculate_hashes(config: dict, export: bytes) -> tuple[dict, dict]:
     """Calculate a hash of the yaml config file."""
     config = config.copy()
@@ -141,6 +189,7 @@ def clean(file_config: FileConfig, write: bool = True):
     :param write: if set to `True`, writes changes to disk.
     """
     people_keys = ("owners", "peers")
+    emeritus_keys = [f"{k}_emeritus" for k in people_keys]
     file_config.load()
     directory = Directory(file_config)
     directory.load()
@@ -156,35 +205,47 @@ def clean(file_config: FileConfig, write: bool = True):
         if "machine_name" not in module:
             module["machine_name"] = generate_machine_readable_name(module["name"])
 
+        for emeritus_key in emeritus_keys:
+            if check_nested_keys_for_value(module, ("meta", emeritus_key)):
+                for i, person in enumerate(module["meta"][emeritus_key]):
+                    if not isinstance(person, dict):
+                        continue
+                    anchor_people_for_module(
+                        i, person, emeritus_key, file_config, directory, module
+                    )
+
         for key in people_keys:
             if key not in module or not module[key]:
                 continue
             for i, person in enumerate(module[key]):
-                if person["bmo_id"] not in directory.people.by_bmo_id:
-                    file_config.config["people"].append(person)
-                    module[key][i] = person
-                    directory.people.refresh_by_bmo_id()
-                else:
-                    module[key][i] = file_config.config["people"][
-                        directory.people.by_bmo_id[person["bmo_id"]]
-                    ]
+                anchor_people_for_module(i, person, key, file_config, directory, module)
 
         # Do the same for submodules.
         if "submodules" in module and module["submodules"]:
             module["submodules"].sort(key=lambda x: x["name"])
             for submodule in module["submodules"]:
+
+                for emeritus_key in emeritus_keys:
+                    if check_nested_keys_for_value(submodule, ("meta", emeritus_key)):
+                        for i, person in enumerate(submodule["meta"][emeritus_key]):
+                            if not isinstance(person, dict):
+                                continue
+                            anchor_people_for_module(
+                                i,
+                                person,
+                                emeritus_key,
+                                file_config,
+                                directory,
+                                submodule,
+                            )
+
                 for key in people_keys:
                     if key not in submodule or not submodule[key]:
                         continue
                     for i, person in enumerate(submodule[key]):
-                        if person["bmo_id"] not in directory.people.by_bmo_id:
-                            file_config.config["people"].append(person)
-                            submodule[key][i] = person
-                            directory.people.refresh_by_bmo_id()
-                        else:
-                            submodule[key][i] = file_config.config["people"][
-                                directory.people.by_bmo_id[person["bmo_id"]]
-                            ]
+                        anchor_people_for_module(
+                            i, person, key, file_config, directory, submodule
+                        )
                 if "machine_name" not in submodule:
                     submodule["machine_name"] = generate_machine_readable_name(
                         submodule["name"]

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -107,7 +107,9 @@ class FileConfig:
             yaml.dump(self.config, f)
 
 
-def check_nested_keys_for_value(dictionary: dict, keys, boolean=True) -> bool:
+def check_nested_keys_for_value(
+    dictionary: dict, keys: list | tuple, boolean=True
+) -> bool:
     """Check a nested key for a value. If boolean is False, checks if the key exists.
 
     For example:
@@ -131,26 +133,37 @@ def check_nested_keys_for_value(dictionary: dict, keys, boolean=True) -> bool:
         return True
 
 
-def anchor_people_for_module(
-    i: int,
+def reference_anchor_for_module(
+    index: int,
     person: dict,
     key: str,
     file_config: FileConfig,
     directory: Directory,
-    module: Module,
+    module: dict,
 ) -> None:
-    """Associate person with a reference to a directory entry if possible."""
-    logger.debug(f"Anchoring {person}({i}) as {key} to {module['machine_name']}")
-    if "emeritus" in key:
-        reference = module["meta"][key]
-    else:
-        reference = module[key]
+    """Associate person with a reference to a directory entry if possible.
+
+        :param index: the position of the person in the referrer field
+        :param person: a dictionary with information about the person to be added
+        :param key: the key (e.g, "peers" or "owners_emeritus") that defines context
+        :param file_config: config context being modified
+        :param module: dictionary of the module in the config being modified
+
+
+    This is needed so that ruamel.yaml can correctly reference anchors to people.
+    """
+    logger.debug(f"Setting reference to {person} as {key} in {module['machine_name']}")
+
+    referrer = module["meta"][key] if key.endswith("_emeritus") else module[key]
+
     if person["bmo_id"] not in directory.people.by_bmo_id:
+        # Person has to be added to directory before adding the reference.
         file_config.config["people"].append(person)
-        reference[i] = person
         directory.people.refresh_by_bmo_id()
+        referrer[index] = person
     else:
-        reference[i] = file_config.config["people"][
+        # Associate the directory entry with the referrer.
+        referrer[index] = file_config.config["people"][
             directory.people.by_bmo_id[person["bmo_id"]]
         ]
 
@@ -206,19 +219,22 @@ def clean(file_config: FileConfig, write: bool = True):
             module["machine_name"] = generate_machine_readable_name(module["name"])
 
         for emeritus_key in emeritus_keys:
-            if check_nested_keys_for_value(module, ("meta", emeritus_key)):
-                for i, person in enumerate(module["meta"][emeritus_key]):
-                    if not isinstance(person, dict):
-                        continue
-                    anchor_people_for_module(
-                        i, person, emeritus_key, file_config, directory, module
-                    )
+            if not check_nested_keys_for_value(module, ("meta", emeritus_key)):
+                continue
+            for i, person in enumerate(module["meta"][emeritus_key]):
+                if not isinstance(person, dict):
+                    continue
+                reference_anchor_for_module(
+                    i, person, emeritus_key, file_config, directory, module
+                )
 
         for key in people_keys:
             if key not in module or not module[key]:
                 continue
             for i, person in enumerate(module[key]):
-                anchor_people_for_module(i, person, key, file_config, directory, module)
+                reference_anchor_for_module(
+                    i, person, key, file_config, directory, module
+                )
 
         # Do the same for submodules.
         if "submodules" in module and module["submodules"]:
@@ -226,24 +242,27 @@ def clean(file_config: FileConfig, write: bool = True):
             for submodule in module["submodules"]:
 
                 for emeritus_key in emeritus_keys:
-                    if check_nested_keys_for_value(submodule, ("meta", emeritus_key)):
-                        for i, person in enumerate(submodule["meta"][emeritus_key]):
-                            if not isinstance(person, dict):
-                                continue
-                            anchor_people_for_module(
-                                i,
-                                person,
-                                emeritus_key,
-                                file_config,
-                                directory,
-                                submodule,
-                            )
+                    if not check_nested_keys_for_value(
+                        submodule, ("meta", emeritus_key)
+                    ):
+                        continue
+                    for i, person in enumerate(submodule["meta"][emeritus_key]):
+                        if not isinstance(person, dict):
+                            continue
+                        reference_anchor_for_module(
+                            i,
+                            person,
+                            emeritus_key,
+                            file_config,
+                            directory,
+                            submodule,
+                        )
 
                 for key in people_keys:
                     if key not in submodule or not submodule[key]:
                         continue
                     for i, person in enumerate(submodule[key]):
-                        anchor_people_for_module(
+                        reference_anchor_for_module(
                             i, person, key, file_config, directory, submodule
                         )
                 if "machine_name" not in submodule:

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -117,11 +117,11 @@ def reference_anchor_for_module(
 ) -> None:
     """Associate person with a reference to a directory entry if possible.
 
-        :param index: the position of the person in the referrer field
-        :param person: a dictionary with information about the person to be added
-        :param key: the key (e.g, "peers" or "owners_emeritus") that defines context
-        :param file_config: config context being modified
-        :param module: dictionary of the module in the config being modified
+    :param index: the position of the person in the referrer field
+    :param person: a dictionary with information about the person to be added
+    :param key: the key (e.g, "peers" or "owners_emeritus") that defines context
+    :param file_config: config context being modified
+    :param module: dictionary of the module in the config being modified
 
 
     This is needed so that ruamel.yaml can correctly reference anchors to people.

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -107,32 +107,6 @@ class FileConfig:
             yaml.dump(self.config, f)
 
 
-def check_nested_keys_for_value(
-    dictionary: dict, keys: list | tuple, boolean=True
-) -> bool:
-    """Check a nested key for a value. If boolean is False, checks if the key exists.
-
-    For example:
-        >>> test = {"a": {"b": {"c": 1, "d": None}}}
-        >>> check_nested_keys_for_value(test, ["a", "b", "c"])
-        True
-        >>> check_nested_keys_for_value(test, ["a", "b", "e"])
-        False
-        >>> check_nested_keys_for_value(test, ["a", "b", "c", "d"])
-        False
-    """
-    value = dictionary
-    for key in keys:
-        if value and isinstance(value, dict):
-            value = value.get(key)
-        else:
-            return False
-    if boolean:
-        return bool(value)
-    else:
-        return True
-
-
 def reference_anchor_for_module(
     index: int,
     person: dict,
@@ -219,7 +193,11 @@ def clean(file_config: FileConfig, write: bool = True):
             module["machine_name"] = generate_machine_readable_name(module["name"])
 
         for emeritus_key in emeritus_keys:
-            if not check_nested_keys_for_value(module, ("meta", emeritus_key)):
+            if not (
+                "meta" in module
+                and emeritus_key in module["meta"]
+                and module["meta"][emeritus_key]
+            ):
                 continue
             for i, person in enumerate(module["meta"][emeritus_key]):
                 if not isinstance(person, dict):
@@ -242,8 +220,10 @@ def clean(file_config: FileConfig, write: bool = True):
             for submodule in module["submodules"]:
 
                 for emeritus_key in emeritus_keys:
-                    if not check_nested_keys_for_value(
-                        submodule, ("meta", emeritus_key)
+                    if not (
+                        "meta" in submodule
+                        and emeritus_key in submodule["meta"]
+                        and submodule["meta"][emeritus_key]
                     ):
                         continue
                     for i, person in enumerate(submodule["meta"][emeritus_key]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def repo(tmp_path, config):
     file_config = FileConfig(test_repo / "mots.yml")
     file_config.config = config
     hashes = {
-        "config": "6ef5f3ed90c5d9aa2eec7b91ed65a78b886e8fa1",
+        "config": "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a",
         "export": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
     }
     file_config.write(hashes)
@@ -87,6 +87,7 @@ def config():
                 "excludes": ["canines/red_fox"],
                 "owners": [people[0]],
                 "peers": [people[1]],
+                "meta": {"peers_emeritus": [people[2]]},
                 "submodules": [
                     {
                         "machine_name": "predators",
@@ -100,6 +101,7 @@ def config():
                             "birds/parrot",
                         ],
                         "owners": [people[1]],
+                        "meta": {"owners_emeritus": [people[2]]},
                     }
                 ],
             },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,9 @@ def test_calculate_hashes(config):
     export = b""
     hashes = calculate_hashes(config, export)[1]
 
-    assert hashes["config"] == "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a"
+    assert (
+        hashes["config"] == "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a"
+    ), "Was `conftest.config` changed?"
     assert hashes["export"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,6 @@
 from mots.config import (
     calculate_hashes,
     FileConfig,
-    check_nested_keys_for_value,
     reference_anchor_for_module,
 )
 from mots.directory import Directory
@@ -40,16 +39,6 @@ def test_FileConfig__check_hashes(repo):
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
         "export file is out of date.",
     ]
-
-
-def test_check_nested_keys_for_value():
-    test = {"a": {"b": {"c": 1, "d": None}, "e": 2}}
-
-    assert check_nested_keys_for_value(test, ("x", "y", "z")) is False
-    assert check_nested_keys_for_value(test, ("a", "b", "c")) is True
-    assert check_nested_keys_for_value(test, ("a", "b", "c", "d")) is False
-    assert check_nested_keys_for_value(test, ("a", "b", "d")) is False
-    assert check_nested_keys_for_value(test, ("a", "b", "d"), boolean=False) is True
 
 
 def test_reference_anchor_for_module(repo):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,14 +4,14 @@
 
 """Test config module."""
 
-from mots.config import calculate_hashes, FileConfig
+from mots.config import calculate_hashes, FileConfig, check_nested_keys_for_value
 
 
 def test_calculate_hashes(config):
     export = b""
     hashes = calculate_hashes(config, export)[1]
 
-    assert hashes["config"] == "6ef5f3ed90c5d9aa2eec7b91ed65a78b886e8fa1"
+    assert hashes["config"] == "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a"
     assert hashes["export"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
 
@@ -26,9 +26,19 @@ def test_FileConfig__check_hashes(repo):
     errors = file_config.check_hashes()
     assert errors == [
         "Mismatch in config hash detected.",
-        "6ef5f3ed90c5d9aa2eec7b91ed65a78b886e8fa1 does not match asdf",
+        "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a does not match asdf",
         "config file is out of date.",
         "Mismatch in export hash detected.",
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
         "export file is out of date.",
     ]
+
+
+def test_check_nested_keys_for_value():
+    test = {"a": {"b": {"c": 1, "d": None}, "e": 2}}
+
+    assert check_nested_keys_for_value(test, ("x", "y", "z")) is False
+    assert check_nested_keys_for_value(test, ("a", "b", "c")) is True
+    assert check_nested_keys_for_value(test, ("a", "b", "c", "d")) is False
+    assert check_nested_keys_for_value(test, ("a", "b", "d")) is False
+    assert check_nested_keys_for_value(test, ("a", "b", "d"), boolean=False) is True


### PR DESCRIPTION
- moved anchoring functionality to its own method
- added method to check nested keys for convenience
- bump version to 0.3.3