### PR TITLE
cli: add mach interface (bug 1797929)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ where = src
 
 [options.entry_points]
 console_scripts =
-    mots = mots.cli:main
+    mots = mots.cli:call_main_with_args
 
 [options.package_data]
 * = templates/*.template.rst

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -287,7 +287,7 @@ def main(
     if hasattr(args, "func"):
         if skip_update_check:
             logger.debug("Skipping update check.")
-        if args.func != check_for_updates and settings.CHECK_FOR_UPDATES:
+        elif args.func != check_for_updates and settings.CHECK_FOR_UPDATES:
             try:
                 _check_for_updates(settings.CHECK_DEV_RELEASES)
             except Exception as e:
@@ -408,8 +408,8 @@ def create_parser(subcommand=None):
     parsers["clean"].add_argument(*path_flags, **path_args)
     parsers["check-hashes"].add_argument(*path_flags, **path_args)
 
-    if subcommand:
-        if subcommand not in parsers:
-            raise ValueError(f"{subcommand} not found.")
-        return parsers[subcommand]
-    return parser
+    if not subcommand:
+        return parser
+    if subcommand not in parsers:
+        raise ValueError(f"{subcommand} not found.")
+    return parsers[subcommand]

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -5,15 +5,11 @@
 """This module sets up parsers and maps cli commands to methods."""
 
 from datetime import datetime
-from packaging.version import Version
 from pathlib import Path
-from xml.etree import ElementTree
 import argparse
 import getpass
 import logging
 import sys
-
-import requests
 
 from mots import module
 from mots import config
@@ -23,7 +19,12 @@ from mots.directory import Directory
 from mots.export import export_to_format
 from mots.logging import init_logging
 from mots.settings import settings
-from mots.utils import get_list_input, mkdir_if_not_exists, touch_if_not_exists
+from mots.utils import (
+    get_list_input,
+    mkdir_if_not_exists,
+    touch_if_not_exists,
+    check_for_updates as _check_for_updates,
+)
 from mots.yaml import yaml
 from mots import __version__
 
@@ -257,44 +258,35 @@ def search(args: argparse.Namespace):
         print(out)
 
 
-def _check_for_updates(include_dev_releases):
-    """
-    Show a message if there is a newer version available.
-
-    This method checks the RSS feed on PyPI.
-    """
-    URL = "https://pypi.org/rss/project/mots/releases.xml"
-    response = requests.get(URL)
-    result = ElementTree.fromstring(response.content)
-    items = result[0].findall("item")
-    versions = [Version(item[0].text) for item in items]
-
-    if not include_dev_releases:
-        versions = [v for v in versions if not v.is_devrelease]
-
-    newest_version = max(versions)
-    if Version(__version__) < newest_version:
-        logger.warning(f"A new version of mots is available ({newest_version})")
-        logger.warning(f"You are running {__version__}")
-    else:
-        logger.debug(f"You are running the latest version of mots ({__version__})")
-
-
 def check_for_updates(args: argparse.Namespace) -> None:
     """CLI wrapper around _check_for_udpdates."""
     _check_for_updates(args.include_dev_releases)
 
 
-def main():
-    """Run startup commands and redirect to appropriate function."""
+def call_main_with_args():
+    """Call `main` after creating a parser and parsing arguments.
+
+    This method is used when running mots directly via the CLI. When mots is run via
+    an integration (e.g., mach), then the integration must call `main` directly with
+    the arguments.
+    """
     parser = create_parser()
     args = parser.parse_args()
+    main(args)
 
+
+def main(
+    args: argparse.Namespace,
+    skip_update_check: bool = False,
+) -> None:
+    """Run startup commands and redirect to appropriate function."""
     mkdir_if_not_exists(settings.RESOURCE_DIRECTORY)
     touch_if_not_exists(settings.OVERRIDES_FILE)
     init_logging(debug=args.debug)
 
     if hasattr(args, "func"):
+        if skip_update_check:
+            logger.debug("Skipping update check.")
         if args.func != check_for_updates and settings.CHECK_FOR_UPDATES:
             try:
                 _check_for_updates(settings.CHECK_DEV_RELEASES)
@@ -312,7 +304,8 @@ def main():
         et = datetime.now()
         logger.debug(f"{args.func} took {(et - st).total_seconds()} seconds.")
     else:
-        parser.print_help()
+        # By default, print help to screen.
+        create_parser().print_help()
 
 
 def _add_path_argument(_parser):
@@ -325,7 +318,7 @@ def _add_path_argument(_parser):
     )
 
 
-def create_parser():
+def create_parser(subcommand=None):
     """Create parser, subparsers, and arguments."""
     parsers = {}
     parser = argparse.ArgumentParser(description="main command line interface for mots")
@@ -415,4 +408,8 @@ def create_parser():
     parsers["clean"].add_argument(*path_flags, **path_args)
     parsers["check-hashes"].add_argument(*path_flags, **path_args)
 
+    if subcommand:
+        if subcommand not in parsers:
+            raise ValueError(f"{subcommand} not found.")
+        return parsers[subcommand]
     return parser

--- a/src/mots/mach_interface.py
+++ b/src/mots/mach_interface.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+This module provides an API to integrate mots within mach.
+
+Be careful to not break backward compatibility here, or you will
+break mach!
+"""
+
+from __future__ import absolute_import
+
+from argparse import Namespace
+
+from mots.cli import create_parser, main
+from mots.utils import check_for_updates
+
+
+parser = create_parser
+new_release_on_pypi = check_for_updates
+
+
+def run(options):
+    """Run mots given a dict of options."""
+    main(
+        args=Namespace(**options),
+        skip_update_check=True,
+    )


### PR DESCRIPTION
- move `_check_for_updates` to `utils`, as it will be used in different modules
- modify the way `main` is called to be compatible with `mach_interface`
- support calling `print_help` for specific parsers, not just the main one
- modify `create_parser` to return a subparser when provided a subcommand
- add `mach_interface` module