### PR TITLE
cli: support not refreshing from BMO for existing users (bug 1782280)

### DIFF
--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -409,7 +409,7 @@ def create_parser(subcommand=None):
     parsers["check-hashes"].add_argument(*path_flags, **path_args)
 
     parsers["clean"].add_argument(
-        "--refresh", action="store_true", help="refresh person data from Bugzilla"
+        "--refresh", action="store_true", help="refresh user data from Bugzilla"
     )
 
     if not subcommand:

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -67,7 +67,7 @@ def clean(args: argparse.Namespace) -> None:
     file_config = config.FileConfig(Path(args.path))
     file_config.load()
     try:
-        config.clean(file_config)
+        config.clean(file_config, refresh=args.refresh)
     except MissingBugzillaAPIKey:
         logger.error("Could not detect a Bugzilla API Key.")
         messages = (
@@ -407,6 +407,10 @@ def create_parser(subcommand=None):
     parsers["validate"].add_argument(*path_flags, **path_args)
     parsers["clean"].add_argument(*path_flags, **path_args)
     parsers["check-hashes"].add_argument(*path_flags, **path_args)
+
+    parsers["clean"].add_argument(
+        "--refresh", action="store_true", help="refresh person data from Bugzilla"
+    )
 
     if not subcommand:
         return parser

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -213,7 +213,10 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
     else:
         # Use the original people list, and update entries only where needed.
         logger.warning("Only synchronizing new people with Bugzilla.")
-        updated_people_dict = {p["bmo_id"]: p for p in updated_people.serialized}
+        updated_people_dict = {
+            updated_person["bmo_id"]: updated_person
+            for updated_person in updated_people.serialized
+        }   
         for person in people:
             if "sync" in person and person["sync"]:
                 logger.info(f"Updated {person['bmo_id']} with new data.")

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -216,7 +216,7 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
         updated_people_dict = {
             updated_person["bmo_id"]: updated_person
             for updated_person in updated_people.serialized
-        }   
+        }
         for person in people:
             if "sync" in person and person["sync"]:
                 logger.info(f"Updated {person['bmo_id']} with new data.")

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -295,7 +295,9 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
         file_config.load()
 
         nicks = []
-        file_config.config["people"].sort(key=lambda person: person.get("nick", "").lower())
+        file_config.config["people"].sort(
+            key=lambda person: person.get("nick", "").lower()
+        )
         for person in file_config.config["people"]:
             machine_readable_nick = generate_machine_readable_name(
                 person.get("nick", ""), keep_case=True

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -295,7 +295,7 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
         file_config.load()
 
         nicks = []
-        file_config.config["people"].sort(key=lambda p: p.get("nick", "").lower())
+        file_config.config["people"].sort(key=lambda person: person.get("nick", "").lower())
         for person in file_config.config["people"]:
             machine_readable_nick = generate_machine_readable_name(
                 person.get("nick", ""), keep_case=True

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -202,9 +202,7 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
     bmo_data = get_bmo_data(people)
     updated_people = People(people, bmo_data)
 
-    for person in people:
-        if "nick" not in person:
-            person["sync"] = True
+    people_to_sync = set(person["bmo_id"] for person in people if "nick" not in person)
 
     if refresh:
         # Use the updated list that was synchronized with Bugzilla.
@@ -218,9 +216,8 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
             for updated_person in updated_people.serialized
         }
         for person in people:
-            if "sync" in person and person["sync"]:
+            if person["bmo_id"] in people_to_sync:
                 logger.info(f"Updated {person['bmo_id']} with new data.")
-                person.pop("sync")
                 person.update(updated_people_dict[person["bmo_id"]])
         file_config.config["people"] = people
 

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -5,6 +5,7 @@
 """Directory classes for mots."""
 from __future__ import annotations
 
+import copy
 from collections import defaultdict
 from dataclasses import asdict
 from dataclasses import dataclass
@@ -92,7 +93,10 @@ class Directory:
                 self.index[path] = [m for m in modules if not m.exclude_module_paths]
         self.index = dict(self.index)
 
-        # Load people directory
+        self.load_people()
+
+    def load_people(self):
+        """Load people directory from config handle."""
         people = list(self.config_handle.config["people"])
         self.people = People(people, {})
 
@@ -185,13 +189,14 @@ class Person:
 class People:
     """A people directory searchable by name, email, or BMO ID."""
 
-    def __init__(self, people, bmo_data: dict):
+    def __init__(self, people: list, bmo_data: dict):
         logger.debug(f"Initializing people directory with {len(people)} people...")
 
         self.people = []
         self.by_bmo_id = {}
 
-        people = list(people)
+        people = copy.deepcopy(people)
+
         for i, person in enumerate(people):
             logger.debug(f"Adding person {person} to roster...")
 

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -189,7 +189,7 @@ class Person:
 class People:
     """A people directory searchable by name, email, or BMO ID."""
 
-    def __init__(self, people: list, bmo_data: dict):
+    def __init__(self, people: list[dict], bmo_data: dict):
         logger.debug(f"Initializing people directory with {len(people)} people...")
 
         self.people = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def config():
                 "submodules": [
                     {
                         "machine_name": "predators",
-                        "name": "Predatord",
+                        "name": "Predators",
                         "includes": [
                             "canines/hyena",
                             "felines/tiger",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def repo(tmp_path, config):
     file_config = FileConfig(test_repo / "mots.yml")
     file_config.config = config
     hashes = {
-        "config": "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b",
+        "config": "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54",
         "export": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
     }
     file_config.write(hashes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def repo(tmp_path, config):
     file_config = FileConfig(test_repo / "mots.yml")
     file_config.config = config
     hashes = {
-        "config": "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a",
+        "config": "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b",
         "export": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
     }
     file_config.write(hashes)
@@ -65,6 +65,7 @@ def config():
         {"name": "jane", "nick": "jane", "bmo_id": 0},
         {"name": "jill", "nick": "jill", "bmo_id": 1},
         {"name": "otis", "nick": "otis", "bmo_id": 2},
+        {"name": "angel", "nick": "angel", "bmo_id": 4},
     ]
     return {
         "repo": "test_repo",
@@ -75,6 +76,7 @@ def config():
         "modules": [
             {
                 "machine_name": "domesticated_animals",
+                "name": "Domesticated Animals",
                 "exclude_submodule_paths": True,
                 "exclude_module_paths": True,
                 "includes": [
@@ -91,6 +93,7 @@ def config():
                 "submodules": [
                     {
                         "machine_name": "predators",
+                        "name": "Predatord",
                         "includes": [
                             "canines/hyena",
                             "felines/tiger",
@@ -107,6 +110,7 @@ def config():
             },
             {
                 "machine_name": "pets",
+                "name": "Pets",
                 "includes": [
                     "canines/**/*",
                     "felines/**/*",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,10 +194,14 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_d
 
     # Compare the old and new people lists without the new entry, they should match.
     new = sorted(
-        [dict(p) for p in file_config.config["people"] if p["bmo_id"] != 3],
+        [
+            dict(person)
+            for person in file_config.config["people"]
+            if person["bmo_id"] != 3
+        ],
         key=itemgetter("bmo_id"),
     )
-    original = sorted([p for p in config["people"]], key=itemgetter("bmo_id"))
+    original = sorted([person for person in config["people"]], key=itemgetter("bmo_id"))
     assert new == original
 
     # Run clean without refresh.
@@ -240,10 +244,14 @@ def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_bmo_user
 
     # Compare the old and new people lists without the new entry, they should match.
     new = sorted(
-        [dict(p) for p in file_config.config["people"] if p["bmo_id"] != 3],
+        [
+            dict(person)
+            for person in file_config.config["people"]
+            if person["bmo_id"] != 3
+        ],
         key=itemgetter("bmo_id"),
     )
-    original = sorted([p for p in config["people"]], key=itemgetter("bmo_id"))
+    original = sorted([person for person in config["people"]], key=itemgetter("bmo_id"))
     assert new == original
 
     # Run clean with refresh.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_calculate_hashes(config):
     hashes = calculate_hashes(config, export)[1]
 
     assert (
-        hashes["config"] == "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b"
+        hashes["config"] == "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54"
     ), "Was `conftest.config` changed?"
     assert hashes["export"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
@@ -50,7 +50,7 @@ def test_FileConfig__check_hashes(repo):
     errors = file_config.check_hashes()
     assert errors == [
         "Mismatch in config hash detected.",
-        "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b does not match asdf",
+        "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54 does not match asdf",
         "config file is out of date.",
         "Mismatch in export hash detected.",
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
@@ -190,7 +190,7 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_d
     for person in file_config.config["people"]:
         if person["bmo_id"] == 3:
             # Ensure only the bmo_id key is there.
-            assert len(person) == 1, "Only the bmo_id key should be present."```
+            assert len(person) == 1, "Only the bmo_id key should be present."
 
     # Compare the old and new people lists without the new entry, they should match.
     new = sorted(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ from mots.directory import Directory
 
 
 @pytest.fixture
-def test_data():
+def test_bmo_user_data():
     return {
         0: {"real_name": "janeway", "nick": "captain", "bmo_id": 0},
         1: {"real_name": "tuvok", "nick": "2vk", "bmo_id": 1},
@@ -93,9 +93,9 @@ def test_reference_anchor_for_module(repo):
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_removed_user_no_refresh(get_bmo_data, repo, config, test_data):
+def test_clean_removed_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_data):
     """Test that removing a user without a refresh has no effect."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -114,9 +114,11 @@ def test_clean_removed_user_no_refresh(get_bmo_data, repo, config, test_data):
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_removed_user_with_refresh(get_bmo_data, repo, config, test_data):
+def test_clean_removed_user_with_refresh(
+    get_bmo_data, repo, config, test_bmo_user_data
+):
     """Test that removing a user with a refresh updates from BMO."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -131,14 +133,14 @@ def test_clean_removed_user_with_refresh(get_bmo_data, repo, config, test_data):
     cleaned_and_sorted = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
     assert len(cleaned_and_sorted) == 3
     for i, person in enumerate(cleaned_and_sorted):
-        assert person["name"] == test_data[i]["real_name"]
-        assert person["nick"] == test_data[i]["nick"]
+        assert person["name"] == test_bmo_user_data[i]["real_name"]
+        assert person["nick"] == test_bmo_user_data[i]["nick"]
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_changed_names(get_bmo_data, repo, config, test_data):
+def test_clean_changed_names(get_bmo_data, repo, config, test_bmo_user_data):
     """Test that updated BMO data will be reflected when cleaning."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -148,14 +150,14 @@ def test_clean_changed_names(get_bmo_data, repo, config, test_data):
     clean(file_config)
 
     for person in file_config.config["people"]:
-        assert person["name"] == test_data[person["bmo_id"]]["real_name"]
-        assert person["nick"] == test_data[person["bmo_id"]]["nick"]
+        assert person["name"] == test_bmo_user_data[person["bmo_id"]]["real_name"]
+        assert person["nick"] == test_bmo_user_data[person["bmo_id"]]["nick"]
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_changed_names_no_refresh(get_bmo_data, repo, config, test_data):
+def test_clean_changed_names_no_refresh(get_bmo_data, repo, config, test_bmo_user_data):
     """Test that updated BMO data has no effect when cleaning without refresh."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -170,9 +172,9 @@ def test_clean_changed_names_no_refresh(get_bmo_data, repo, config, test_data):
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_data):
+def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_data):
     """Test that updated BMO data has no effect when cleaning without refresh."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -211,9 +213,9 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_data):
 
 
 @mock.patch("mots.config.get_bmo_data")
-def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_data):
+def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_bmo_user_data):
     """Test that updated BMO data is reflected when cleaning with a refresh."""
-    get_bmo_data.return_value = test_data
+    get_bmo_data.return_value = test_bmo_user_data
 
     file_config = FileConfig(repo / "mots.yml")
     file_config.load()
@@ -249,3 +251,4 @@ def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_data):
     assert cleaned[1] == {"bmo_id": 1, "name": "tuvok", "nick": "2vk"}
     assert cleaned[2] == {"bmo_id": 2, "name": "neelix", "nick": "cooks4u"}
     assert cleaned[3] == {"bmo_id": 3, "name": "seven", "nick": "nanotubes"}
+    assert cleaned[4] == {"bmo_id": 4, "name": "tom paris", "nick": "paris"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,7 +190,7 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_d
     for person in file_config.config["people"]:
         if person["bmo_id"] == 3:
             # Ensure only the bmo_id key is there.
-            assert len(person) == 1
+            assert len(person) == 1, "Only the bmo_id key should be present."```
 
     # Compare the old and new people lists without the new entry, they should match.
     new = sorted(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,12 +4,29 @@
 
 """Test config module."""
 
+from operator import itemgetter
+from unittest import mock
+
+import pytest
+
 from mots.config import (
-    calculate_hashes,
     FileConfig,
+    calculate_hashes,
+    clean,
     reference_anchor_for_module,
 )
 from mots.directory import Directory
+
+
+@pytest.fixture
+def test_data():
+    return {
+        0: {"real_name": "janeway", "nick": "captain", "bmo_id": 0},
+        1: {"real_name": "tuvok", "nick": "2vk", "bmo_id": 1},
+        2: {"real_name": "neelix", "nick": "cooks4u", "bmo_id": 2},
+        3: {"real_name": "seven", "nick": "nanotubes", "bmo_id": 3},
+        4: {"real_name": "tom paris", "nick": "paris", "bmo_id": 4},
+    }
 
 
 def test_calculate_hashes(config):
@@ -17,7 +34,7 @@ def test_calculate_hashes(config):
     hashes = calculate_hashes(config, export)[1]
 
     assert (
-        hashes["config"] == "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a"
+        hashes["config"] == "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b"
     ), "Was `conftest.config` changed?"
     assert hashes["export"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
@@ -33,7 +50,7 @@ def test_FileConfig__check_hashes(repo):
     errors = file_config.check_hashes()
     assert errors == [
         "Mismatch in config hash detected.",
-        "76997b8d70e561c7ec8a21e1cefbc3c658c6d91a does not match asdf",
+        "983f96583e8ba0e6cc86c72e04d5c6d40cdc151b does not match asdf",
         "config file is out of date.",
         "Mismatch in export hash detected.",
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
@@ -73,3 +90,162 @@ def test_reference_anchor_for_module(repo):
     )
 
     assert id(owner_emeritus_field[0]) == id(file_config.config["people"][0])
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_removed_user_no_refresh(get_bmo_data, repo, config, test_data):
+    """Test that removing a user without a refresh has no effect."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    file_config.config["people"].pop()
+    file_config.write()
+
+    clean(file_config, refresh=False)
+
+    cleaned_and_sorted = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
+    assert len(cleaned_and_sorted) == 3
+    for i, person in enumerate(cleaned_and_sorted):
+        assert person == file_config.config["people"][i]
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_removed_user_with_refresh(get_bmo_data, repo, config, test_data):
+    """Test that removing a user with a refresh updates from BMO."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    file_config.config["people"].pop()
+    file_config.write()
+
+    clean(file_config, refresh=True)
+
+    cleaned_and_sorted = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
+    assert len(cleaned_and_sorted) == 3
+    for i, person in enumerate(cleaned_and_sorted):
+        assert person["name"] == test_data[i]["real_name"]
+        assert person["nick"] == test_data[i]["nick"]
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_changed_names(get_bmo_data, repo, config, test_data):
+    """Test that updated BMO data will be reflected when cleaning."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    clean(file_config)
+
+    for person in file_config.config["people"]:
+        assert person["name"] == test_data[person["bmo_id"]]["real_name"]
+        assert person["nick"] == test_data[person["bmo_id"]]["nick"]
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_changed_names_no_refresh(get_bmo_data, repo, config, test_data):
+    """Test that updated BMO data has no effect when cleaning without refresh."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    clean(file_config, refresh=False)
+
+    assert sorted(file_config.config["people"], key=itemgetter("bmo_id")) == sorted(
+        config["people"], key=itemgetter("bmo_id")
+    )
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_data):
+    """Test that updated BMO data has no effect when cleaning without refresh."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    file_config.config["people"].append({"bmo_id": 3})
+    file_config.write()
+
+    assert len(file_config.config["people"]) == 5
+
+    # Check that the new entry is unaffected after write.
+    for person in file_config.config["people"]:
+        if person["bmo_id"] == 3:
+            # Ensure only the bmo_id key is there.
+            assert len(person) == 1
+
+    # Compare the old and new people lists without the new entry, they should match.
+    new = sorted(
+        [dict(p) for p in file_config.config["people"] if p["bmo_id"] != 3],
+        key=itemgetter("bmo_id"),
+    )
+    original = sorted([p for p in config["people"]], key=itemgetter("bmo_id"))
+    assert new == original
+
+    # Run clean without refresh.
+    clean(file_config, refresh=False)
+
+    # It is expected that only the new entry is updated, and the rest are intact.
+    cleaned = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
+    assert len(cleaned) == 5
+    assert cleaned[0] == original[0]
+    assert cleaned[1] == original[1]
+    assert cleaned[2] == original[2]
+    assert cleaned[3] == {"bmo_id": 3, "name": "seven", "nick": "nanotubes"}
+
+
+@mock.patch("mots.config.get_bmo_data")
+def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_data):
+    """Test that updated BMO data is reflected when cleaning with a refresh."""
+    get_bmo_data.return_value = test_data
+
+    file_config = FileConfig(repo / "mots.yml")
+    file_config.load()
+
+    assert file_config.config["people"] == config["people"]
+
+    file_config.config["people"].append({"bmo_id": 3})
+    file_config.write()
+
+    assert len(file_config.config["people"]) == 5
+
+    # Check that the new entry is unaffected after write.
+    for person in file_config.config["people"]:
+        if person["bmo_id"] == 3:
+            # Ensure only the bmo_id key is there.
+            assert len(person) == 1
+
+    # Compare the old and new people lists without the new entry, they should match.
+    new = sorted(
+        [dict(p) for p in file_config.config["people"] if p["bmo_id"] != 3],
+        key=itemgetter("bmo_id"),
+    )
+    original = sorted([p for p in config["people"]], key=itemgetter("bmo_id"))
+    assert new == original
+
+    # Run clean with refresh.
+    clean(file_config, refresh=True)
+
+    # It is expected that all people will have been updated via BMO.
+    cleaned = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
+    assert len(cleaned) == 5
+    assert cleaned[0] == {"bmo_id": 0, "name": "janeway", "nick": "captain"}
+    assert cleaned[1] == {"bmo_id": 1, "name": "tuvok", "nick": "2vk"}
+    assert cleaned[2] == {"bmo_id": 2, "name": "neelix", "nick": "cooks4u"}
+    assert cleaned[3] == {"bmo_id": 3, "name": "seven", "nick": "nanotubes"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,12 +204,17 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_bmo_user_d
     clean(file_config, refresh=False)
 
     # It is expected that only the new entry is updated, and the rest are intact.
+    explain_assert_existing = "Existing records should not be updated after clean."
     cleaned = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
     assert len(cleaned) == 5
-    assert cleaned[0] == original[0]
-    assert cleaned[1] == original[1]
-    assert cleaned[2] == original[2]
-    assert cleaned[3] == {"bmo_id": 3, "name": "seven", "nick": "nanotubes"}
+    assert cleaned[0] == original[0], explain_assert_existing
+    assert cleaned[1] == original[1], explain_assert_existing
+    assert cleaned[2] == original[2], explain_assert_existing
+    assert cleaned[3] == {
+        "bmo_id": 3,
+        "name": "seven",
+        "nick": "nanotubes",
+    }, "New entry should have been updated after clean."
 
 
 @mock.patch("mots.config.get_bmo_data")
@@ -245,10 +250,31 @@ def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_bmo_user
     clean(file_config, refresh=True)
 
     # It is expected that all people will have been updated via BMO.
+    explain_assert_all = "Record should have been updated after clean."
     cleaned = sorted(file_config.config["people"], key=itemgetter("bmo_id"))
     assert len(cleaned) == 5
-    assert cleaned[0] == {"bmo_id": 0, "name": "janeway", "nick": "captain"}
-    assert cleaned[1] == {"bmo_id": 1, "name": "tuvok", "nick": "2vk"}
-    assert cleaned[2] == {"bmo_id": 2, "name": "neelix", "nick": "cooks4u"}
-    assert cleaned[3] == {"bmo_id": 3, "name": "seven", "nick": "nanotubes"}
-    assert cleaned[4] == {"bmo_id": 4, "name": "tom paris", "nick": "paris"}
+    assert cleaned[0] == {
+        "bmo_id": 0,
+        "name": "janeway",
+        "nick": "captain",
+    }, explain_assert_all
+    assert cleaned[1] == {
+        "bmo_id": 1,
+        "name": "tuvok",
+        "nick": "2vk",
+    }, explain_assert_all
+    assert cleaned[2] == {
+        "bmo_id": 2,
+        "name": "neelix",
+        "nick": "cooks4u",
+    }, explain_assert_all
+    assert cleaned[3] == {
+        "bmo_id": 3,
+        "name": "seven",
+        "nick": "nanotubes",
+    }, explain_assert_all
+    assert cleaned[4] == {
+        "bmo_id": 4,
+        "name": "tom paris",
+        "nick": "paris",
+    }, explain_assert_all

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,7 +179,7 @@ def test_clean_added_user_no_refresh(get_bmo_data, repo, config, test_data):
 
     assert file_config.config["people"] == config["people"]
 
-    file_config.config["people"].append({"bmo_id": 3})
+    file_config.config["people"].insert(1, {"bmo_id": 3})
     file_config.write()
 
     assert len(file_config.config["people"]) == 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,7 +251,7 @@ def test_clean_added_user_with_refresh(get_bmo_data, repo, config, test_bmo_user
         ],
         key=itemgetter("bmo_id"),
     )
-    original = sorted([person for person in config["people"]], key=itemgetter("bmo_id"))
+    original = sorted(config["people"], key=itemgetter("bmo_id"))
     assert new == original
 
     # Run clean with refresh.

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -81,6 +81,7 @@ def test_export_format_people_for_rst(config):
         "\n        | `jane (jane) <https://people.mozilla.org/s?query=jane>`__"
         "\n        | `jill (jill) <https://people.mozilla.org/s?query=jill>`__"
         "\n        | `otis (otis) <https://people.mozilla.org/s?query=otis>`__"
+        "\n        | `angel (angel) <https://people.mozilla.org/s?query=angel>`__"
         "\n        | `unnamed <https://people.mozilla.org/s?query=unnamed>`__"
     )
 


### PR DESCRIPTION
- add --refresh parameter to clean command
- add mock bmo_data and tests
- fix bug when referencing non-existent user (bug 1814237)
- add unreferenced user to config fixture

With this change, by default, `mots clean` will not refresh all user
data with updated Bugzilla data. Instead, only users that do not have a
nickname will trigger this update. If --refresh is passed, then all
users will have their data updated.

Please also see related [bug 1803651](https://bugzilla.mozilla.org/show_bug.cgi?id=1803651).