### PR TITLE
export: md template support (bug 1820780)

### DIFF
--- a/src/mots/templates/directory.template.md
+++ b/src/mots/templates/directory.template.md
@@ -1,0 +1,87 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public #}
+{# License, v. 2.0. If a copy of the MPL was not distributed with this #}
+{# file, You can obtain one at <https://mozilla.org/MPL/2.0/>. #}
+
+<!-- This file was automatically generated using `mots export`.
+
+  See https://mots.readthedocs.io/en/latest/#quick-start for quick
+start documentation and how to modify this file. -->
+
+{% macro module_entry(module, is_submodule=False) -%}
+{{ "###" if not is_submodule else "####" }} {{ module.name }}
+
+{% if module.description %}
+{{ module.description|escape_for_md|trim|wordwrap }}
+{% endif %}
+
+{% if not module.owners %}
+```{warning}
+    This module does not have any owners specified.
+```
+{% endif %}
+```{list-table}
+---
+stub-columns: 1
+widths: 30 70
+---
+{% if module.owners %}
+* - Owner(s)
+  -{{ module.owners|format_people_for_md(indent=4) }}
+{% endif %}
+{% if module.peers %}
+* - Peer(s)
+  -{{ module.peers|format_people_for_md(indent=4) }}
+{% endif %}
+{% if module.meta.owners_emeritus %}
+* - Owner(s) Emeritus
+  - {{ module.meta.owners_emeritus|format_emeritus }}
+{% endif %}
+{% if module.meta.peers_emeritus %}
+* - Peer(s) Emeritus
+  - {{ module.meta.peers_emeritus|format_emeritus }}
+{% endif %}
+{% if module.includes %}
+* - Includes
+  -{{ module.includes|format_paths_for_md(directory=directory, indent=4) }}
+{% endif %}
+{% if module.excludes %}
+* - Excludes
+  -{{ module.excludes|format_paths_for_md(directory=directory, indent=4) }}
+{% endif %}
+{% if module.meta.group %}
+* - Group
+  - {{ module.meta.group|trim }}
+{% endif %}
+{% if module.meta.url %}
+* - URL
+  - {{ module.meta.url|trim }}
+{% endif %}
+{% if module.meta.components %}
+* - Bugzilla Components
+  - {{ module.meta.components|join(", ")|wordwrap|indent(width=4) }}
+{% endif %}
+```
+{% endmacro %}
+
+
+# Governance
+
+## Overview
+
+To add, remove, or update module information, see the
+[mots documentation](https://mots.readthedocs.io/en/latest/#adding-a-module>).
+
+{{ directory.description|wordwrap }}
+
+
+## Modules
+
+{% for module in directory.modules -%}
+{{ module_entry(module) }}
+{% if module.submodules %}
+{% for submodule in module.submodules %}
+{{ module_entry(submodule, True) }}
+
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -11,8 +11,11 @@ import pytest
 from mots.export import (
     export_to_format,
     escape_for_rst,
+    escape_for_md,
     format_paths_for_rst,
+    format_paths_for_md,
     format_people_for_rst,
+    format_people_for_md,
     format_emeritus,
 )
 
@@ -22,6 +25,9 @@ def test_export_to_format(exporter):
     directory = mock.MagicMock()
     test = export_to_format(directory, frmt="rst")
     assert test == exporter(directory)._export_to_rst()
+
+    test2 = export_to_format(directory, frmt="md")
+    assert test2 == exporter(directory)._export_to_md()
 
     with pytest.raises(ValueError):
         export_to_format(directory, frmt="unsupported-format")
@@ -43,6 +49,28 @@ def test_escape_for_rst():
     )
 
     assert expected_string == escape_for_rst(test_string)
+
+
+def test_escape_for_md():
+    test_string = (
+        "A couple of backslashes \\ \\\n"
+        "A couple of asterisks * *\n"
+        "A couple of hashmarks # #\n"
+        "A couple of bangs ! !\n"
+        "A couple of backticks ` `\n"
+        "All on one line: \\ * # ! `"
+    )
+
+    expected_string = (
+        "A couple of backslashes \\\\ \\\\\n"
+        "A couple of asterisks \\* \\*\n"
+        "A couple of hashmarks \\# \\#\n"
+        "A couple of bangs \\! \\!\n"
+        "A couple of backticks \\` \\`\n"
+        "All on one line: \\\\ \\* \\# \\! \\`"
+    )
+
+    assert expected_string == escape_for_md(test_string)
 
 
 def test_export_format_paths_for_rst():
@@ -73,6 +101,34 @@ def test_export_format_paths_for_rst():
     )
 
 
+def test_export_format_paths_for_md():
+    """Ensure outputted strings are correct when formatting paths."""
+    mock_directory = mock.MagicMock()
+    mock_directory.config_handle.config = {
+        "export": {"searchfox_enabled": True},
+        "repo": "test-repo",
+    }
+
+    paths = ["test_path_1", "test_path_2"]
+
+    assert format_paths_for_md(paths, indent=4, directory=mock_directory) == (
+        "\n    * [test_path_1]"
+        "(https://searchfox.org/test-repo/search?q=&path=test_path_1)"
+        "\n    * [test_path_2]"
+        "(https://searchfox.org/test-repo/search?q=&path=test_path_2)"
+    )
+
+    mock_directory.config_handle.config = {
+        "repo": "test-repo",
+    }
+
+    paths = ["test_path_1", "test_path_2"]
+
+    assert format_paths_for_md(paths, indent=4, directory=mock_directory) == (
+        "\n    * test_path_1" "\n    * test_path_2"
+    )
+
+
 def test_export_format_people_for_rst(config):
     """Ensure outputted strings are correct when formatting people."""
     config["people"].append({"nick": "unnamed"})
@@ -82,6 +138,18 @@ def test_export_format_people_for_rst(config):
         "\n        | `jill (jill) <https://people.mozilla.org/s?query=jill>`__"
         "\n        | `otis (otis) <https://people.mozilla.org/s?query=otis>`__"
         "\n        | `unnamed <https://people.mozilla.org/s?query=unnamed>`__"
+    )
+
+
+def test_export_format_people_for_md(config):
+    """Ensure outputted strings are correct when formatting people."""
+    config["people"].append({"nick": "unnamed"})
+    test = format_people_for_md(config["people"], indent=4)
+    assert test == (
+        "\n    * [jane (jane)](https://people.mozilla.org/s?query=jane)"
+        "\n    * [jill (jill)](https://people.mozilla.org/s?query=jill)"
+        "\n    * [otis (otis)](https://people.mozilla.org/s?query=otis)"
+        "\n    * [unnamed](https://people.mozilla.org/s?query=unnamed)"
     )
 
 


### PR DESCRIPTION
For Thunderbird docs, Markdown is the preferred format. The Markdown template is a direct port from the RST`version and makes use of [MyST](https://myst-parser.readthedocs.io/en/latest/index.html). 