### PR TITLE
utils: do not include pre-releases by default (bug 1815709)

### DIFF
--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -397,7 +397,6 @@ def create_parser(subcommand=None):
     parsers["search"].add_argument("match", nargs=1, help="a search string")
     parsers["check-for-updates"].add_argument(
         "--include-pre-releases",
-        "-d",
         action="store_true",
         help="include pre releases in check",
         default=settings.CHECK_PRE_RELEASES,

--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -260,7 +260,7 @@ def search(args: argparse.Namespace):
 
 def check_for_updates(args: argparse.Namespace) -> None:
     """CLI wrapper around _check_for_udpdates."""
-    _check_for_updates(args.include_dev_releases)
+    _check_for_updates(args.include_pre_releases)
 
 
 def call_main_with_args():
@@ -289,7 +289,7 @@ def main(
             logger.debug("Skipping update check.")
         elif args.func != check_for_updates and settings.CHECK_FOR_UPDATES:
             try:
-                _check_for_updates(settings.CHECK_DEV_RELEASES)
+                _check_for_updates(settings.CHECK_PRE_RELEASES)
             except Exception as e:
                 logger.warning("Could not check for updates.")
                 logger.debug(e)
@@ -396,11 +396,11 @@ def create_parser(subcommand=None):
 
     parsers["search"].add_argument("match", nargs=1, help="a search string")
     parsers["check-for-updates"].add_argument(
-        "--include-dev-releases",
+        "--include-pre-releases",
         "-d",
         action="store_true",
-        help="include dev releases in check",
-        default=settings.CHECK_DEV_RELEASES,
+        help="include pre releases in check",
+        default=settings.CHECK_PRE_RELEASES,
     )
 
     parsers["init"].add_argument(*path_flags, **path_args)

--- a/src/mots/settings.py
+++ b/src/mots/settings.py
@@ -28,7 +28,7 @@ class Settings:
     DEFAULTS = {
         "BUGZILLA_API_KEY": "",
         "BUGZILLA_URL": "https://bugzilla.mozilla.org/rest",
-        "CHECK_DEV_RELEASES": 0,
+        "CHECK_PRE_RELEASES": 0,
         "CHECK_FOR_UPDATES": 1,
         "CIRCLECI_TAG_KEY": "CIRCLE_TAG",
         "DEBUG": 0,

--- a/src/mots/utils.py
+++ b/src/mots/utils.py
@@ -67,7 +67,7 @@ def touch_if_not_exists(path: Path):
         logger.warning(f"{path} exists but is not a file.")
 
 
-def check_for_updates(include_dev_releases: bool = False) -> Version | None:
+def check_for_updates(include_pre_releases: bool = False) -> Version | None:
     """
     Show a message if there is a newer version available.
 
@@ -79,8 +79,8 @@ def check_for_updates(include_dev_releases: bool = False) -> Version | None:
     items = result[0].findall("item")
     versions = [Version(item[0].text) for item in items]
 
-    if not include_dev_releases:
-        versions = [v for v in versions if not v.is_devrelease]
+    if not include_pre_releases:
+        versions = [v for v in versions if not v.is_prerelease]
 
     newest_version = max(versions)
     if Version(__version__) < newest_version:


### PR DESCRIPTION
Currently, check-for-updates will include pre-releases and treat them as new releases, and will only exclude dev releases if that particular setting is set. Instead, all pre-releases should be treated the same.