### PR TITLE
templates: add `meta.review_group` (bug 1782278)

### DIFF
--- a/src/mots/export.py
+++ b/src/mots/export.py
@@ -43,6 +43,16 @@ def escape_for_md(value: str) -> str:
     return value
 
 
+def format_link_for_rst(text: str, url: str) -> str:
+    """Format a link."""
+    return f"`{text} <{url}>`__"
+
+
+def format_link_for_md(text: str, url: str) -> str:
+    """Format a link."""
+    return f"[{text}]({url})"
+
+
 def format_paths_for_rst(
     value: list[str], indent: int, directory: Directory = None
 ) -> str:
@@ -57,9 +67,9 @@ def format_paths_for_rst(
     for path in value:
         path = path.replace("*", "\\*")
         if searchfox_enabled:
-            path = (
-                f"`{path} <{settings.SEARCHFOX_BASE_URL}"
-                f"/{config['repo']}/search?q=&path={path}>`__"
+            path = format_link_for_rst(
+                path,
+                f"{settings.SEARCHFOX_BASE_URL}/{config['repo']}/search?q=&path={path}",
             )
         parsed_paths.append(path)
     return f"\n{' ' * indent}| " + f"\n{' ' * indent}| ".join(parsed_paths)
@@ -79,9 +89,9 @@ def format_paths_for_md(
     for path in value:
         path = path.replace("*", "\\*")
         if searchfox_enabled:
-            path = (
-                f"[{path}]({settings.SEARCHFOX_BASE_URL}"
-                f"/{config['repo']}/search?q=&path={path})"
+            path = format_link_for_md(
+                path,
+                f"{settings.SEARCHFOX_BASE_URL}/{config['repo']}/search?q=&path={path}",
             )
         parsed_paths.append(path)
     return f"\n{' ' * indent}* " + f"\n{' ' * indent}* ".join(parsed_paths)
@@ -92,13 +102,13 @@ def format_people_for_rst(value: list[dict], indent: int) -> str:
     people_base_url = settings.PMO_SEARCH_URL
     parsed_people = []
     for person in value:
+        url = f"{people_base_url}{person['nick']}"
         if "name" in person and person["name"]:
-            parsed_person = (
-                f"`{person['name']} ({person['nick']}) "
-                f"<{people_base_url}{person['nick']}>`__"
+            parsed_person = format_link_for_rst(
+                f"{person['name']} ({person['nick']})", url
             )
         else:
-            parsed_person = f"`{person['nick']} <{people_base_url}{person['nick']}>`__"
+            parsed_person = format_link_for_rst(person["nick"], url)
 
         parsed_people.append(parsed_person)
     return f"\n{' ' * indent}| " + f"\n{' ' * indent}| ".join(parsed_people)
@@ -109,13 +119,13 @@ def format_people_for_md(value: list[dict], indent: int) -> str:
     people_base_url = settings.PMO_SEARCH_URL
     parsed_people = []
     for person in value:
+        url = f"{people_base_url}{person['nick']}"
         if "name" in person and person["name"]:
-            parsed_person = (
-                f"[{person['name']} ({person['nick']})]"
-                f"({people_base_url}{person['nick']})"
+            parsed_person = format_link_for_md(
+                f"{person['name']} ({person['nick']})", url
             )
         else:
-            parsed_person = f"[{person['nick']}]({people_base_url}{person['nick']})"
+            parsed_person = format_link_for_md(person["nick"], url)
 
         parsed_people.append(parsed_person)
     return f"\n{' ' * indent}* " + f"\n{' ' * indent}* ".join(parsed_people)

--- a/src/mots/export.py
+++ b/src/mots/export.py
@@ -145,6 +145,18 @@ def format_emeritus(value: list[dict | str]) -> str:
     return ", ".join(parsed)
 
 
+def format_review_group_for_rst(group: str) -> str:
+    """Format a review group."""
+    base_url = settings.PHABRICATOR_BASE_URL
+    return format_link_for_rst(f"#{group}", f"{base_url}/tag/{group}/")
+
+
+def format_review_group_for_md(group: str) -> str:
+    """Format a review group."""
+    base_url = settings.PHABRICATOR_BASE_URL
+    return format_link_for_md(f"#{group}", f"{base_url}/tag/{group}/")
+
+
 class Exporter:
     """A helper class that exports to various formats."""
 
@@ -158,9 +170,11 @@ class Exporter:
         env.filters["escape_for_rst"] = escape_for_rst
         env.filters["format_paths_for_rst"] = format_paths_for_rst
         env.filters["format_people_for_rst"] = format_people_for_rst
+        env.filters["format_review_group_for_rst"] = format_review_group_for_rst
         env.filters["escape_for_md"] = escape_for_md
         env.filters["format_paths_for_md"] = format_paths_for_md
         env.filters["format_people_for_md"] = format_people_for_md
+        env.filters["format_review_group_for_md"] = format_review_group_for_md
         env.filters["format_emeritus"] = format_emeritus
         return env
 

--- a/src/mots/settings.py
+++ b/src/mots/settings.py
@@ -43,6 +43,7 @@ class Settings:
         "PMO_URL": "https://people.mozilla.org/api/v4",
         "RESOURCE_DIRECTORY": RESOURCE_DIRECTORY,
         "SEARCHFOX_BASE_URL": "https://searchfox.org",
+        "PHABRICATOR_BASE_URL": "https://phabricator.services.mozilla.com",
         "USER_AGENT": f"mots/{__version__}",
         "VERSION": __version__,
     }

--- a/src/mots/templates/directory.template.md
+++ b/src/mots/templates/directory.template.md
@@ -60,6 +60,10 @@ widths: 30 70
 * - Bugzilla Components
   - {{ module.meta.components|join(", ")|wordwrap|indent(width=4) }}
 {% endif %}
+{% if module.meta.review_group %}
+* - Review Group
+  - {{ module.meta.review_group|trim|format_review_group_for_md }}
+{% endif %}
 ```
 {% endmacro %}
 

--- a/src/mots/templates/directory.template.rst
+++ b/src/mots/templates/directory.template.rst
@@ -60,6 +60,10 @@
     * - Bugzilla Components
       - {{ module.meta.components|join(", ")|wordwrap|indent(width=8) }}
 {% endif %}
+{% if module.meta.review_group %}
+    * - Review Group
+      - {{ module.meta.review_group|format_review_group_for_rst }}
+{% endif %}
 {% endmacro %}
 
 ==========

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -16,6 +16,8 @@ from mots.export import (
     format_paths_for_md,
     format_people_for_rst,
     format_people_for_md,
+    format_review_group_for_rst,
+    format_review_group_for_md,
     format_emeritus,
 )
 
@@ -159,3 +161,15 @@ def test_export_format_emeritus(config):
     emeritus = ["maggie", config["people"][0]]
     test = format_emeritus(emeritus)
     assert test == "maggie, jane"
+
+
+def test_export_format_review_group_for_rst():
+    """Ensure outputted strings are correct when formatting review group."""
+    test = format_review_group_for_rst("foo")
+    assert test == "`#foo <https://phabricator.services.mozilla.com/tag/foo/>`__"
+
+
+def test_export_format_review_group_for_md():
+    """Ensure outputted strings are correct when formatting review group."""
+    test = format_review_group_for_md("foo")
+    assert test == "[#foo](https://phabricator.services.mozilla.com/tag/foo/)"


### PR DESCRIPTION
I set this field as a string field instead of a list as IMO a module with multiple review groups should be represented as multiple submodules.