### PR TITLE
fix: add encoding and newline parameters (bug 1845802)

### DIFF
--- a/src/mots/cli.py
+++ b/src/mots/cli.py
@@ -164,7 +164,7 @@ def export(args: argparse.Namespace) -> None:
         # Explicit output path was not provided, try to get it from config.
         if file_config.config.get("export", {}).get("path"):
             out_path = Path(file_config.config["export"]["path"])
-            with out_path.open("w", encoding="utf-8") as f:
+            with out_path.open("w", encoding="utf-8", newline="\n") as f:
                 logger.info(f"Writing output to specified file path ({out_path})...")
                 f.write(output)
         else:
@@ -173,7 +173,7 @@ def export(args: argparse.Namespace) -> None:
     else:
         # TODO: do more checks here to make sure we don't overwrite important things.
         logger.info(f"Writing output to specified file path ({args.out})...")
-        with args.out.open("w", encoding="utf-8") as f:
+        with args.out.open("w", encoding="utf-8", newline="\n") as f:
             f.write(output)
 
 
@@ -219,7 +219,7 @@ def write(args: argparse.Namespace):
         f"{key} is now set to {value_output} ({_type.__name__}) in overrides file."
     )
 
-    with settings.OVERRIDES_FILE.open("w", encoding="utf-8") as f:
+    with settings.OVERRIDES_FILE.open("w", encoding="utf-8", newline="\n") as f:
         yaml.dump(overrides, f)
 
 

--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -118,7 +118,7 @@ class FileConfig:
         logger.debug(f"Writing configuration to {self.path}")
         self.config["updated_at"] = datetime.now().isoformat()
         self.config["hashes"] = hashes or {}
-        with self.path.open("w") as f:
+        with self.path.open("w", encoding="utf-8", newline="\n") as f:
             yaml.dump(self.config, f)
 
 


### PR DESCRIPTION
Adding `newline` while we are at it, so that it won't emit `\r\n` on Windows.