### PR TITLE
config: allow plain text in owners/peers field (bug 1923018)

### DIFF
--- a/src/mots/config.py
+++ b/src/mots/config.py
@@ -42,6 +42,11 @@ MPL2 = "\n".join(
     )
 )
 
+# A list of nicks allowed to be used without a bugzilla ID.
+ALLOWED_NICK_ONLY = [
+    "TLMC",
+]
+
 
 class ValidationError(TypeError):
     """Thrown when a particular module is not valid."""
@@ -244,6 +249,13 @@ def clean(file_config: FileConfig, write: bool = True, refresh: bool = True):
             if key not in module or not module[key]:
                 continue
             for i, person in enumerate(module[key]):
+                if "bmo_id" not in person:
+                    if person.get("nick") not in ALLOWED_NICK_ONLY:
+                        raise ValueError(
+                            f"Nick must be one of {', '.join(ALLOWED_NICK_ONLY)} when "
+                            "provided without bmo_id."
+                        )
+                    continue
                 reference_anchor_for_module(
                     i, person, key, file_config, directory, module
                 )

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -14,7 +14,7 @@ import logging
 from mots.module import Module
 from mots.utils import parse_real_name
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from mots.config import FileConfig
@@ -192,13 +192,13 @@ class QueryResult:
 class Person:
     """A class representing a person."""
 
-    bmo_id: int
-    name: str
-    nick: str
+    bmo_id: Optional[int] = None
+    name: Optional[str] = ""
+    nick: Optional[str] = ""
 
     def __hash__(self):
         """Return a unique identifier for this person."""
-        return self.bmo_id
+        return self.bmo_id or hash(self.nick)
 
 
 class People:
@@ -215,7 +215,9 @@ class People:
         for i, person in enumerate(people):
             logger.debug(f"Adding person {person} to roster...")
 
-            bmo_id = person["bmo_id"] = int(person["bmo_id"])
+            bmo_id = person["bmo_id"] = (
+                int(person["bmo_id"]) if "bmo_id" in person else None
+            )
             if bmo_id in bmo_data and bmo_data[bmo_id]:
                 # Update person's data base on BMO data.
                 bmo_datum = bmo_data[person["bmo_id"]]

--- a/src/mots/export.py
+++ b/src/mots/export.py
@@ -107,8 +107,10 @@ def format_people_for_rst(value: list[dict], indent: int) -> str:
             parsed_person = format_link_for_rst(
                 f"{person['name']} ({person['nick']})", url
             )
-        else:
+        elif "bmo_id" in person:
             parsed_person = format_link_for_rst(person["nick"], url)
+        else:
+            parsed_person = person["nick"]
 
         parsed_people.append(parsed_person)
     return f"\n{' ' * indent}| " + f"\n{' ' * indent}| ".join(parsed_people)
@@ -124,8 +126,10 @@ def format_people_for_md(value: list[dict], indent: int) -> str:
             parsed_person = format_link_for_md(
                 f"{person['name']} ({person['nick']})", url
             )
-        else:
+        elif "bmo_id" in person:
             parsed_person = format_link_for_md(person["nick"], url)
+        else:
+            parsed_person = person["nick"]
 
         parsed_people.append(parsed_person)
     return f"\n{' ' * indent}* " + f"\n{' ' * indent}* ".join(parsed_people)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -140,7 +140,7 @@ def test_export_format_people_for_rst(config):
         "\n        | `jill (jill) <https://people.mozilla.org/s?query=jill>`__"
         "\n        | `otis (otis) <https://people.mozilla.org/s?query=otis>`__"
         "\n        | `angel (angel) <https://people.mozilla.org/s?query=angel>`__"
-        "\n        | `unnamed <https://people.mozilla.org/s?query=unnamed>`__"
+        "\n        | unnamed"
     )
 
 
@@ -153,7 +153,7 @@ def test_export_format_people_for_md(config):
         "\n    * [jill (jill)](https://people.mozilla.org/s?query=jill)"
         "\n    * [otis (otis)](https://people.mozilla.org/s?query=otis)"
         "\n    * [angel (angel)](https://people.mozilla.org/s?query=angel)"
-        "\n    * [unnamed](https://people.mozilla.org/s?query=unnamed)"
+        "\n    * unnamed"
     )
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -97,6 +97,35 @@ def test_module__Module__submodule_with_no_peers_or_owners(repo):
     assert len(m.submodules[0].owners) == 0
 
 
+def test_module__Module__with_peers_and_owners_without_bmo_id(repo):
+    """Ensure a module's string peers/owners are ignored.
+
+    Only references to people listed in the directory should be stored
+    in the module itself. However, the export should include the plain
+    text references.
+    """
+    m = dict(
+        name="Some Module",
+        machine_name="some_module",
+        owners=[{"nick": "otis", "bmo_id": 2}, {"nick": "owner string"}],
+        peers=[{"nick": "jill", "bmo_id": 1}, {"nick": "peer string"}],
+        includes="*",
+        submodules=[
+            dict(
+                name="Submodule",
+                machine_name="submodule",
+                peers=[{"nick": "submodule peer string"}],
+                excludes="some_path",
+            ),
+        ],
+    )
+    m = Module(**m, repo_path=str(repo))
+    assert len(m.peers) == 2
+    assert len(m.owners) == 2
+    assert len(m.submodules[0].peers) == 1
+    assert len(m.submodules[0].owners) == 0
+
+
 def test_module__Module__validate__invalid_machine_name(repo):
     """Ensure an error is thrown when a submodule has an invalid machine name."""
     m = dict(


### PR DESCRIPTION
- skip records with no bmo_id when generating yaml anchors/references
- make all Person attributes optional
- use nick for hash when bmo_id is not set
- allow null values in bmo_id
- restrict which nicks can be set without a bmo_id