### PR TITLE
directory: skip owners/peers if they do not have bmo_id (bug 1936373)

### DIFF
--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -129,7 +129,11 @@ class Directory:
         peers_and_owners = set()
         for module in modules_and_submodules:
             peers_and_owners.update(
-                [person["bmo_id"] for person in module.peers + module.owners]
+                [
+                    person["bmo_id"]
+                    for person in module.peers + module.owners
+                    if "bmo_id" in person
+                ]
             )
         return sorted(list(peers_and_owners))
 

--- a/src/mots/directory.py
+++ b/src/mots/directory.py
@@ -121,12 +121,16 @@ class Directory:
 
     @property
     def peers_and_owners(self):
-        """Return a sorted list of all peers and owners."""
+        """Return a sorted list of all peers and owners, excluding aliases."""
         all_modules = self.modules
         all_submodules = list(chain(*[module.submodules for module in all_modules]))
         modules_and_submodules = all_modules + all_submodules
 
         peers_and_owners = set()
+
+        # NOTE: aliases are free-form text entires that do not link back to a Bugzilla
+        # ID. Records without a bmo_id key are treated as such.
+
         for module in modules_and_submodules:
             peers_and_owners.update(
                 [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def repo(tmp_path, config):
     file_config = FileConfig(test_repo / "mots.yml")
     file_config.config = config
     hashes = {
-        "config": "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54",
+        "config": "b69f7e77313ac6b47e90d4f3298f32bbd668b3f5",
         "export": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
     }
     file_config.write(hashes)
@@ -67,10 +67,12 @@ def config():
         {"name": "otis", "nick": "otis", "bmo_id": 2},
         {"name": "angel", "nick": "angel", "bmo_id": 4},
     ]
+    aliases = [{"nick": "TLMC"}]
     return {
         "repo": "test_repo",
         "created_at": "2021-09-10 12:53:22.383393",
         "updated_at": "2021-09-10 12:53:22.383393",
+        "aliases": aliases,
         "people": people,
         "export": {"format": "rst", "path": "mots.rst"},
         "modules": [
@@ -87,7 +89,7 @@ def config():
                     "pigs/**/*",
                 ],
                 "excludes": ["canines/red_fox"],
-                "owners": [people[0]],
+                "owners": [people[0], aliases[0]],
                 "peers": [people[1]],
                 "meta": {"peers_emeritus": [people[2]]},
                 "submodules": [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_calculate_hashes(config):
     hashes = calculate_hashes(config, export)[1]
 
     assert (
-        hashes["config"] == "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54"
+        hashes["config"] == "b69f7e77313ac6b47e90d4f3298f32bbd668b3f5"
     ), "Was `conftest.config` changed?"
     assert hashes["export"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
@@ -50,7 +50,7 @@ def test_FileConfig__check_hashes(repo):
     errors = file_config.check_hashes()
     assert errors == [
         "Mismatch in config hash detected.",
-        "f14a84e9e7a9f39ece7ac7232e2f55dda4da6e54 does not match asdf",
+        "b69f7e77313ac6b47e90d4f3298f32bbd668b3f5 does not match asdf",
         "config file is out of date.",
         "Mismatch in export hash detected.",
         "da39a3ee5e6b4b0d3255bfef95601890afd80709 does not match ghjk",
@@ -299,9 +299,7 @@ def test_clean_added_user_no_bmo_id_with_refresh(
 
     assert file_config.config["people"] == config["people"]
     file_config.config["modules"][0]["owners"].append({"nick": "TLMC"})
-    file_config.config["modules"][0]["submodules"][0]["owners"].append(
-        {"nick": "TLMC"}
-    )
+    file_config.config["modules"][0]["submodules"][0]["owners"].append({"nick": "TLMC"})
     file_config.write()
 
     assert len(file_config.config["people"]) == 4
@@ -373,9 +371,7 @@ def test_clean_added_user_no_bmo_id_with_refresh_invalid_nick(
 
     clean(file_config, refresh=True)
 
-    file_config.config["modules"][0]["submodules"][0]["owners"].append(
-        {"nick": "ABCD"}
-    )
+    file_config.config["modules"][0]["submodules"][0]["owners"].append({"nick": "ABCD"})
     file_config.write()
 
     # Run clean with refresh, this time after changing a submodule.

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -20,7 +20,7 @@ def test_module__Module(repo):
     assert len(m.includes) == 5
     assert len(m.excludes) == 1
     assert len(m.submodules) == 1
-    assert len(m.owners) == 1
+    assert len(m.owners) == 2
 
     assert m.submodules[0].machine_name == "predators"
     assert len(m.submodules[0].includes) == 4


### PR DESCRIPTION
- add aliases to main config fixture
- update tests